### PR TITLE
Fix initialisation of the mongoActor

### DIFF
--- a/mongo/src/test/scala/blueeyes/persistence/mongo/MongoStageSpec.scala
+++ b/mongo/src/test/scala/blueeyes/persistence/mongo/MongoStageSpec.scala
@@ -63,7 +63,7 @@ class MongoStageSpec extends Specification with ScalaCheck with MongoImplicits w
         }
 
         val start = System.currentTimeMillis
-        val futures = Future.sequence[Unit, List](actors.map(actor => (actor ? "Send").mapTo[Unit])))
+        val futures = Future.sequence[Unit, List](actors.map(actor => (actor ? "Send").mapTo[Unit]))
         futures.value must eventually(200, 300.milliseconds) (beSome)
 
         val flushFuture = mongoStage.flushAll(Timeout(10000))
@@ -72,8 +72,8 @@ class MongoStageSpec extends Specification with ScalaCheck with MongoImplicits w
         forall(updates) {
           case (filter, update: UpdateFieldFunctions.IncF) =>
             mockDatabase(select().from(collection).where(filter)).map(_.toList) must whenDelivered {
-              beLike { 
-                case x :: xs => 
+              beLike {
+                case x :: xs =>
                   val setValue = update.value.asInstanceOf[MongoPrimitiveInt].value
                   val value    = update.path.extract(x)
                   value must_== JsonAST.JInt(setValue * sendCount * actorsCount)

--- a/mongo/src/test/scala/blueeyes/persistence/mongo/RealMongoBenchmarkSpec.scala
+++ b/mongo/src/test/scala/blueeyes/persistence/mongo/RealMongoBenchmarkSpec.scala
@@ -40,7 +40,7 @@ class RealMongoBenchmarkSpec extends Specification with ArbitraryJValue with Mon
       val actors = List.range(1, 50) map {index =>
         defaultActorSystem.actorOf(Props(new MessageActor(alphaStr.sample.get, alphaStr.sample.get, index)))
       }
-      val futures = Future.sequence(actors.map(actor => (actor ? ("send")(2000)).mapTo[Tuple3[Future[Option[JObject]], String, String]]))
+      val futures = Future.sequence(actors.map(actor => (actor.?("send")(2000)).mapTo[Tuple3[Future[Option[JObject]], String, String]]))
       futures must whenDelivered {
         beLike {
           case list => forall(list) {
@@ -72,4 +72,3 @@ class RealMongoBenchmarkSpec extends Specification with ArbitraryJValue with Mon
     }
   }
 }
-


### PR DESCRIPTION
As discussed on the mailing list. This pull request includes a fix for the initialisation of the mongo actor to it doesn't throw an exception on initialisation.

I also made the Mongo tests compile again.

BTW, you've turned off MockMongo in tests. That is, tests use real Mongo. (See commented out line in BlueEyesServiceSpecification.) You might want to revert this change.
