### PR TITLE
Fix race condition in configuration of BlueEyesServiceSpecifications

### DIFF
--- a/core/src/main/scala/blueeyes/core/service/test/BlueEyesServiceSpecification.scala
+++ b/core/src/main/scala/blueeyes/core/service/test/BlueEyesServiceSpecification.scala
@@ -14,7 +14,7 @@ import blueeyes.core.service._
 import blueeyes.util.RichThrowableImplicits._
 
 import java.util.concurrent.{TimeUnit, CountDownLatch}
-import net.lag.configgy.{Config, Configgy}
+import net.lag.configgy.Config
 
 import org.specs2.mutable.Specification
 import org.specs2.specification.{Fragment, Fragments, Step}
@@ -72,8 +72,7 @@ class BlueEyesServiceSpecification extends Specification with blueeyes.concurren
   private def stopServer  = Await.result(httpServer.stop,  new DurationLong(stopTimeOut) millis)
 
   lazy val rootConfig = {
-    Configgy.configureFromString(configuration)
-    Configgy.config
+    Config.fromString(configuration)
   }
 
   private class SpecClient extends HttpClient[ByteChunk]{


### PR DESCRIPTION
I'm aware you're rewriting the config code to use Configrity. However, this pull request fixes a bug I'm hitting right now in tests for the current project at Untyped:

`BlueEyesServiceSpecification` used a non-thread-safe part of the Configgy API that causes errors in  specifications.

`Configgy.configureFromString` uses a "global" variable, `Configgy.config`, to store the parsed configuration. Overwriting this variable can cause race conditions between instances of `BlueEyesServiceSpecification` that are simultaneously starting up.

This commit changes `BlueEyesServiceSpecification` to use Configgy's `Config.fromString` method, which avoids use of `Configgy.config`.
