### PR TITLE
Change underscores to hyphens in actor system names

### DIFF
--- a/core/src/main/scala/blueeyes/concurrent/FutureDispatch.scala
+++ b/core/src/main/scala/blueeyes/concurrent/FutureDispatch.scala
@@ -10,9 +10,9 @@ trait AkkaDefaults {
 }
 
 object AkkaDefaults {
-  val actorSystem = ActorSystem("blueeyes_actors")
+  val actorSystem = ActorSystem("blueeyes-actors")
 
-  val defaultFutureDispatch: MessageDispatcher = actorSystem.dispatchers.lookup("blueeyes_async")
+  val defaultFutureDispatch: MessageDispatcher = actorSystem.dispatchers.lookup("blueeyes-async")
 }
 
 // vim: set ts=4 sw=4 et:

--- a/core/src/main/scala/blueeyes/health/metrics/TimedSample.scala
+++ b/core/src/main/scala/blueeyes/health/metrics/TimedSample.scala
@@ -17,7 +17,7 @@ import histogram.{DynamicHistogram, ValueStrategy}
 
 abstract class TimedSample[V](val config: interval)(implicit valueStrategy: ValueStrategy[V], clock: Clock, m: Manifest[V])
 extends AsyncStatistic[Long, Map[Long, V]]{
-  val actorSystem = ActorSystem("timed_sample") //TODO: Specialize
+  val actorSystem = ActorSystem("timed-sample") //TODO: Specialize
   private[TimedSample] val actor = actorSystem.actorOf(Props(new TimedSampleActor(DynamicHistogram.empty(config.granularity.length, config.samples + 1, config.granularity.unit))))
 
   def +=(elem: Long): this.type = {
@@ -48,7 +48,7 @@ object TimedSample {
 
 private[metrics] class TimedSampleActor[V](var histogram: DynamicHistogram[V]) extends Actor {
   def receive = {
-    case DataRequest(time, data) => 
+    case DataRequest(time, data) =>
       histogram = histogram += (time, data)
 
     case DetailsRequest(promise) =>
@@ -56,7 +56,7 @@ private[metrics] class TimedSampleActor[V](var histogram: DynamicHistogram[V]) e
       val incomplete = details.keySet.toList.sortWith(_ > _).head
       promise.complete(Right(details - incomplete))
 
-    case CountRequest(promise) => 
+    case CountRequest(promise) =>
       promise.complete(Right(histogram.count))
   }
 }

--- a/core/src/main/scala/blueeyes/persistence/cache/Stage.scala
+++ b/core/src/main/scala/blueeyes/persistence/cache/Stage.scala
@@ -29,7 +29,7 @@ abstract class Stage[K, V](monitor: HealthMonitor = HealthMonitor.Noop) {
 
   def maximumCapacity: Int
 
-  private val actorSystem = ActorSystem("blueeyes_stage")
+  private val actorSystem = ActorSystem("blueeyes-stage")
 
   private class Cache extends scala.collection.mutable.Map[K, ExpirableValue[V]] { self =>
     private val impl = new javolution.util.FastMap[K, ExpirableValue[V]]
@@ -47,7 +47,7 @@ abstract class Stage[K, V](monitor: HealthMonitor = HealthMonitor.Noop) {
 
     def -= (k: K): this.type = {
       Option(impl.get(k)) foreach { v =>
-        flush(k, v.value) 
+        flush(k, v.value)
         impl.remove(k)
       }
 

--- a/core/src/test/scala/blueeyes/bkka/StoppableSpec.scala
+++ b/core/src/test/scala/blueeyes/bkka/StoppableSpec.scala
@@ -1,6 +1,6 @@
 package blueeyes.bkka
 
-import org.specs2.mutable.Specification 
+import org.specs2.mutable.Specification
 import akka.actor.Actor
 import akka.actor.ActorSystem
 import akka.actor.Props
@@ -14,7 +14,7 @@ import akka.util.Timeout
 import java.util.concurrent.TimeUnit
 
 class StoppableSpec extends Specification with AkkaDefaults {
-  val actorSystem = ActorSystem("stoppable_spec")
+  val actorSystem = ActorSystem("stoppable-spec")
   implicit val timeout = Timeout(1000)
   val random = new scala.util.Random
 
@@ -40,8 +40,8 @@ class StoppableSpec extends Specification with AkkaDefaults {
       val b2a = new TestStopTarget("b2a")
 
       val stoppable = Stoppable(
-        root, 
-        Stoppable(a1, Stoppable(b1a) :: Stoppable(b1b) :: Nil) :: 
+        root,
+        Stoppable(a1, Stoppable(b1a) :: Stoppable(b1b) :: Nil) ::
         Stoppable(a2, Stoppable(b2a) :: Nil) :: Nil
       )
 


### PR DESCRIPTION
This change is in anticipation of a fix in Akka 2.0.1 that disallows underscores in actor system names:

```
https://github.com/akka/akka/commit/bcbe878ec64b8b23a9d2b97c727c150137fcd30e
```

The change to the dispatcher name in `FutureDispatch.scala` is not required - it's purely there for consistency.

I kept the changes to a minimum in this pull request so I haven't actually bumped the version number on the Akka dependency.

I've been testing this fix on a recent fork of Blueeyes (taken a month or so ago). Everything seems to work ok there. However, I couldn't run the unit tests because of a broken dependency:

```
[warn]  [NOT FOUND  ] org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016!javax.servlet.orbit (644ms)
[warn] ==== Sonatype Jetty: tried
[warn]   https://oss.sonatype.org/content/groups/jetty/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.orbit
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::              FAILED DOWNLOADS            ::
[warn]  :: ^ see resolution messages for details  ^ ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016!javax.servlet.orbit
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[error] {file:/Users/dave/dev/projects/blueeyes-davegurnell/}core/*:update: sbt.ResolveException: download failed: org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016!javax.servlet.orbit
```

Not sure what to do about that!

Cheers,

-- Dave
