### PR TITLE
Fix repeated decoding of response content

### DIFF
--- a/core/src/main/scala/blueeyes/core/service/HttpClient.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpClient.scala
@@ -74,7 +74,7 @@ trait HttpClient[A] extends HttpClientHandler[A] { self =>
       request.copy(content = request.content.map(transcoder.apply(_)), headers = request.headers + Tuple2("Content-Type", mimeType.value))
     } map {response =>
       val newC = response.content.map(transcoder.unapply(_))
-      response.copy(content = response.content.map(transcoder.unapply(_)))
+      response.copy(content = newC)
     }
   }
 
@@ -85,7 +85,7 @@ trait HttpClient[A] extends HttpClientHandler[A] { self =>
       request.copy(content = request.content.map(transcoder.apply(_)))
     } map {response =>
       val newC = response.content.map(transcoder.unapply(_))
-      response.copy(content = response.content.map(transcoder.unapply(_)))
+      response.copy(content = newC)
     }
   }
 


### PR DESCRIPTION
In both the `contentType` and `translate` methods of `HttpClient` (/core/service/HttpClient.scala), it appears a new variable had been introduced for the decoded content, but that variable was never referenced. This caused an extra, unnecessary, call to `transcoder.unapply` for every request via the client.
