### PR TITLE
Fix compilation of 0.6.x branch against latest scalaz-seven

### DIFF
--- a/json/build.sbt
+++ b/json/build.sbt
@@ -3,7 +3,7 @@ name := "blueeyes-json"
 publishArtifact in Test := true
 
 libraryDependencies ++= Seq(
-  "org.scalaz"                  %% "scalaz-core"        % "7.0-SNAPSHOT" changing(),
+  "org.scalaz"                  %  "scalaz-core_2.9.2"  % "7.0-SNAPSHOT" changing(),
   "joda-time"                   %  "joda-time"          % "1.6.2"          % "optional",
   "org.specs2"                  %  "specs2_2.9.1"       % "1.10"           % "test",
   "org.scala-tools.testing"     %  "scalacheck_2.9.1"   % "1.9"            % "test"

--- a/json/src/main/scala/blueeyes/json/JsonAST.scala
+++ b/json/src/main/scala/blueeyes/json/JsonAST.scala
@@ -229,7 +229,7 @@ object JsonAST {
      */
     def insertAll(other: JValue): ValidationNEL[Throwable, JValue] = {
       other.flattenWithPath.foldLeft[ValidationNEL[Throwable, JValue]](success(self)) {
-        case (acc, (path, value)) => acc flatMap { (jv: JValue) => jv.insert(path, value).toValidationNel }
+        case (acc, (path, value)) => acc flatMap { (jv: JValue) => jv.insert(path, value).toValidationNEL }
       }
     }
 

--- a/mongo/src/main/scala/blueeyes/persistence/mongo/MongoBijection.scala
+++ b/mongo/src/main/scala/blueeyes/persistence/mongo/MongoBijection.scala
@@ -22,7 +22,7 @@ trait MongoBijection[V, F, O <: V] extends PartialBijection[DBObject, O] {
   def extractRegex  (value: java.util.regex.Pattern): ValidationNEL[String, V]
   def extractBinary (value: Array[Byte]): ValidationNEL[String, V]
   def extractId     (value: ObjectId): ValidationNEL[String, V]
-  def extractOther  (value: Any) = ("No extractor configured for value of type " + value.getClass.getName).fail.toValidationNel
+  def extractOther  (value: Any) = ("No extractor configured for value of type " + value.getClass.getName).fail.toValidationNEL
   def buildNull: ValidationNEL[String, V]
 
   def buildArray  (values: Seq[V]): V

--- a/mongo/src/main/scala/blueeyes/persistence/mongo/RealMongoImplementation.scala
+++ b/mongo/src/main/scala/blueeyes/persistence/mongo/RealMongoImplementation.scala
@@ -223,15 +223,15 @@ private[mongo] class RealDatabaseCollection(val collection: DBCollection, databa
   private def toMongoKeys(keysPaths: Iterable[JPath]): JObject = JObject(keysPaths.map(key => JField(JPathExtension.toMongoField(key), JInt(1))).toList)
   private def toMongoFilter(filter: Option[MongoFilter])       = filter.map(_.filter.asInstanceOf[JObject]).getOrElse(JObject(Nil))
 
-  private implicit def unvalidated(v: ValidationNEL[String, JObject]): JObject = v ||| {
+  private implicit def unvalidated(v: ValidationNEL[String, JObject]): JObject = v valueOr {
     errors => sys.error("An error occurred deserializing the database object: " + errors.list.mkString("; "))
   }
 
-  private implicit def jvo2dbo(obj: JObject): DBObject = MongoToJson.unapply(obj) ||| {
+  private implicit def jvo2dbo(obj: JObject): DBObject = MongoToJson.unapply(obj) valueOr {
     errors => sys.error("An error occurred serializing the JSON object to mongo: " + errors.list.mkString("; "))
   }
 
-  private def dbo2jvo(dbo: DBObject): JObject = MongoToJson(dbo) ||| {
+  private def dbo2jvo(dbo: DBObject): JObject = MongoToJson(dbo) valueOr {
     errors => sys.error("Errors occurred deserializing the explain object: " + errors.list.mkString("; "))
   }
 }

--- a/mongo/src/main/scala/blueeyes/persistence/mongo/json/BijectionsMongoJson.scala
+++ b/mongo/src/main/scala/blueeyes/persistence/mongo/json/BijectionsMongoJson.scala
@@ -23,9 +23,9 @@ object MongoJValueBijection extends MongoBijection[JValue, JField, JObject] {
   override def extractFloat  (value: java.lang.Float)         = JDouble(value.doubleValue).success
   override def extractDouble (value: java.lang.Double)        = JDouble(value.doubleValue).success
   override def extractBoolean(value: java.lang.Boolean)       = JBool(value).success
-  override def extractDate   (value: java.util.Date)          = "Date type is not supported".fail.toValidationNel
-  override def extractRegex  (value: java.util.regex.Pattern) = "Regex type is not supported".fail.toValidationNel
-  override def extractBinary (value: Array[Byte])             = "Binary type is not supported".fail.toValidationNel
+  override def extractDate   (value: java.util.Date)          = "Date type is not supported".fail.toValidationNEL
+  override def extractRegex  (value: java.util.regex.Pattern) = "Regex type is not supported".fail.toValidationNEL
+  override def extractBinary (value: Array[Byte])             = "Binary type is not supported".fail.toValidationNEL
   override def extractId     (value: ObjectId)                = JString("ObjectId(\"" + Hex.encodeHexString(value.toByteArray) + "\")").success
   override def buildNull                                      = JNull.success
 


### PR DESCRIPTION
Fixed the scala version of the scalaz-core dependency at 2.9.2, because the latest scalaz-seven head is not cross-building to 2.9.1 any more.
