### PR TITLE
Bump scala version to 2.9.2

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "javolution"                  % "javolution"          % "5.5.1",
   "com.typesafe.akka"           % "akka-actor"          % "2.0.2",
   "org.streum"                  %%  "configrity-core"   % "0.10.2",
-  "com.weiglewilczek.slf4s"     %%  "slf4s"             % "1.0.7",
+  "com.weiglewilczek.slf4s"     %  "slf4s_2.9.1"        % "1.0.7",
   "org.mockito"                 %  "mockito-all"        % "1.9.0"          % "test",
   "javax.servlet"               % "javax.servlet-api"   % "3.0.1",
   "org.eclipse.jetty"           % "jetty-server"        % "8.1.3.v20120416"          % "test",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -63,6 +63,8 @@ object BlueEyesBuild extends Build {
   val specs2Version = "1.12.3-SNAPSHOT"
 
   val commonSettings = Seq(
+    scalaVersion := "2.9.2",
+
     crossScalaVersions := Seq("2.9.2"),
 
     version := "1.0.0-SNAPSHOT",


### PR DESCRIPTION
2.9.1 had already been removed from the cross-compile versions, but with SBT 0.11.3 it still builds for 2.9.1 by default, which means that it pulls in an old build of scalaz-seven.
