### PR TITLE
According to the relevant RFC header names are case insensitive. This pr...

### DIFF
--- a/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
+++ b/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
@@ -9,7 +9,7 @@ sealed trait HttpHeaderField[T <: HttpHeader] extends ProductPrefixUnmangler {
   lazy val name: String = unmangledName
 
   def parse(s: String): Option[T]
-  def parse(t: (String, String)): Option[T] = 
+  def parse(t: (String, String)): Option[T] =
     if (t._1.equalsIgnoreCase(name)) parse(t._2) else None
 
   override def toString = name
@@ -49,7 +49,7 @@ object HttpHeaderField {
     Via,
     Warning,
 
-    /** Responses **/
+    // Responses
     Age,
     Allow,
     `Cache-Control`,
@@ -98,7 +98,7 @@ object HttpHeaderField {
       case _ => false
     } else fields.filterNot {
       case NullHeader => true
-      case _ => false 
+      case _ => false
     }
   }
 }
@@ -141,7 +141,7 @@ sealed trait HttpHeaderRequest extends HttpHeader
 sealed trait HttpHeaderResponse extends HttpHeader
 
 case class HttpHeaders private (val raw: Map[String, String]) {
-  def + (kv: (String, String)): HttpHeaders = new HttpHeaders(raw + kv)
+  def + (kv: (String, String)): HttpHeaders = this + HttpHeader(kv)
   def + (header: HttpHeader): HttpHeaders = new HttpHeaders(raw + header.tuple)
   def ++ (that: HttpHeaders) = new HttpHeaders(raw ++ that.raw)
 
@@ -170,7 +170,7 @@ object HttpHeaders {
 
   val Empty: HttpHeaders = new HttpHeaders(Map.empty[String, String])
 
-  /************ Requests ************/
+  // Requests
 
   case class Accept(mimeTypes: MimeType*) extends HttpHeaderRequest {
     def value = mimeTypes.map(_.value).mkString(", ")
@@ -411,7 +411,7 @@ object HttpHeaders {
     def unapply(t: (String, String)) = parse(t).map(_.warnings)
   }
 
-  /*********** Responses ************/
+  // Responses
 
   case class Age(age: Double) extends HttpHeaderResponse {
     def value = age.toString
@@ -471,7 +471,7 @@ object HttpHeaders {
     def unapply(t: (String, String)) = parse(t).map(_.disposition)
   }
 
-  case class `Content-MD5`(value: String) extends HttpHeaderRequest with HttpHeaderResponse 
+  case class `Content-MD5`(value: String) extends HttpHeaderRequest with HttpHeaderResponse
   implicit case object `Content-MD5` extends HttpHeaderField[`Content-MD5`] {
     override def parse(s: String) = Some(apply(s))
     def unapply(t: (String, String)) = parse(t).map(_.value)
@@ -578,7 +578,7 @@ object HttpHeaders {
   }
 
   /* There are problems with using Vary in IE.  */
-  case class Vary(value: String) extends HttpHeaderResponse 
+  case class Vary(value: String) extends HttpHeaderResponse
   implicit case object Vary extends HttpHeaderField[Vary] {
     override def parse(s: String) = Some(apply(s))
     def unapply(t: (String, String)) = parse(t).map(_.value)
@@ -682,7 +682,7 @@ object HttpHeaders {
     def unapply(t: (String, String)) = parse(t).map(_.fields)
   }
 
-  case class CustomHeader(override val name: String, val value: String) extends HttpHeaderRequest with HttpHeaderResponse 
+  case class CustomHeader(override val name: String, val value: String) extends HttpHeaderRequest with HttpHeaderResponse
 
   class NullHeader extends HttpHeader {
     def value = ""

--- a/core/src/test/scala/blueeyes/core/http/HttpHeadersSpec.scala
+++ b/core/src/test/scala/blueeyes/core/http/HttpHeadersSpec.scala
@@ -10,11 +10,16 @@ class HttpHeadersSpec extends Specification{
       headers.header[Authorization] must beSome(Authorization("foo"))
     }
 
+    "maintain case-insensitivity when appending tuple" in {
+      val headers = HttpHeaders.Empty + ("authorization" -> "foo")
+      headers.header[Authorization] must beSome(Authorization("foo"))
+    }
+
     "extract known header types" in {
       val headers = Map("authorization" -> "foo")
 
       val auths = for (Authorization(auth) <- headers) yield auth
-      auths must_== List("foo") 
+      auths must_== List("foo")
     }
     "extract Host header types without scheme" in {
       val headers = Map("Host" -> "localhost:8585")


### PR DESCRIPTION
...operty wasn't always maintained by the HttpHeaders class. This patch fixes the erroneous case.
