### PR TITLE
This commit fixes three bugs in the Json <-> Chunk bijection:

### DIFF
--- a/core/src/main/scala/blueeyes/core/data/BijectionsChunkJson.scala
+++ b/core/src/main/scala/blueeyes/core/data/BijectionsChunkJson.scala
@@ -7,19 +7,31 @@ import akka.dispatch.Future
 import akka.dispatch.Await
 import akka.util.Timeout
 
-trait BijectionsChunkJson{
+trait BijectionsChunkJson {
   import java.io.{InputStreamReader, ByteArrayInputStream, OutputStreamWriter, ByteArrayOutputStream}
 
+  val jsonTimeout = Timeout(200)
+
   implicit val JValueToChunk = new Bijection[JValue, ByteChunk] {
+
     def apply(t: JValue) = {
       val stream = new ByteArrayOutputStream()
 
-      compact(render(t), new OutputStreamWriter(stream))
+      compact(render(t), new OutputStreamWriter(stream, "UTF-8"))
 
       Chunk(stream.toByteArray)
     }
 
-    def unapply(s: ByteChunk) = JsonParser.parse(new InputStreamReader(new ByteArrayInputStream(s.data), "UTF-8"))
+    def unapply(s: ByteChunk) = {
+      val futureJson = AggregatedByteChunk(s, None).map(
+          chunk =>
+            JsonParser.parse(
+              new InputStreamReader(new ByteArrayInputStream(chunk.data), "UTF-8")
+            )
+        )
+
+      Await.result(futureJson, jsonTimeout.duration)
+    }
   }
 
   implicit val ChunkToJValue    = JValueToChunk.inverse
@@ -28,15 +40,16 @@ trait BijectionsChunkJson{
 object BijectionsChunkJson extends BijectionsChunkJson
 
 
-trait BijectionsChunkFutureJson{
+trait BijectionsChunkFutureJson {
   import BijectionsChunkJson._
-  implicit def futureJValueToChunk(implicit timeout: Timeout = Timeout.zero) = new Bijection[Future[JValue], ByteChunk] {
+
+  implicit def futureJValueToChunk(implicit timeout: Timeout = jsonTimeout) = new Bijection[Future[JValue], ByteChunk] {
     def apply(t: Future[JValue]) = Await.result(t.map(JValueToChunk(_)), timeout.duration)
 
     def unapply(b: ByteChunk) = AggregatedByteChunk(b, None).map(ChunkToJValue(_))
   }
 
-  implicit def chunkToFutureJValue(implicit timeout: Timeout = Timeout.zero) = futureJValueToChunk(timeout).inverse
+  implicit def chunkToFutureJValue(implicit timeout: Timeout = jsonTimeout) = futureJValueToChunk(timeout).inverse
 }
 
 object BijectionsChunkFutureJson extends BijectionsChunkFutureJson

--- a/core/src/test/scala/blueeyes/core/data/BijectionsChunkJsonSpec.scala
+++ b/core/src/test/scala/blueeyes/core/data/BijectionsChunkJsonSpec.scala
@@ -1,16 +1,35 @@
 package blueeyes.core.data
 
+import akka.dispatch.Future
 import org.specs2.mutable.Specification
+import blueeyes.bkka.AkkaDefaults
 import blueeyes.json.JsonAST._
 import blueeyes.json.JsonParser.ParseException
 
-class BijectionsChunkJsonSpec extends Specification with BijectionsChunkJson{
-  "BijectionsChunkJson" should{
-    "parser valid JSON" in{
+class BijectionsChunkJsonSpec extends Specification with BijectionsChunkJson with AkkaDefaults {
+  "BijectionsChunkJson" should {
+
+    "parser valid JSON" in {
       JValueToChunk.unapply(Chunk("""{"foo": "bar"}""".getBytes())) mustEqual(JObject(List(JField("foo", JString("bar")))))
     }
-    "throw error when JSON is incomplete" in{
-      JValueToChunk.unapply(Chunk("""{"foo": "bar""".getBytes())) must throwA[ParseException]
+
+    "throw error when JSON is incomplete" in {
+      JValueToChunk.unapply(Chunk("{\"foo\": \"bar\"".getBytes())) must throwA[ParseException]
+    }
+
+    "parse multi-chunk chunk" in {
+      val str1 = "{\"foo\": "
+      val str2 = "\"bar\"}"
+      val chunky = Chunk(str1.getBytes(), Some(Future(Chunk(str2.getBytes(), None))))
+
+      JValueToChunk.unapply(chunky) mustEqual JObject(List(JField("foo", JString("bar"))))
+    }
+
+    "encode non-ascii data correctly" in {
+      val nonAscii = "♠éüλ"
+      val json = JObject(List(JField("foo", JString(nonAscii))))
+
+      JValueToChunk.unapply(JValueToChunk.apply(json)) mustEqual json
     }
   }
 }


### PR DESCRIPTION
1. When converting a byte chunk to JSON the entire chunk is decoded, not just the first chunk in the chain.

Let me elaborate on this because it fixes a huge oversight. A chunk is a lazy list of Array[Byte]. The old implementation would only read the first element of the list. Given the default element size is 8K, if you attempted to read in JSON off the wire that was over 8K that data would be dropped. Yes really! It happened to us in production! This is now fixed.
1. I/O is always done using UTF-8, instead of the system encoding. This allows Unicode characters to be correctly handled.
2. A non-zero timeout is used when converting between chunks and JSON. (Default is 200ms). We had timeouts in production. Now we don't.
