### PR TITLE
Modify RealMongoSpecSupport to use random port

### DIFF
--- a/mongo/src/main/scala/blueeyes/persistence/mongo/RealMongo.scala
+++ b/mongo/src/main/scala/blueeyes/persistence/mongo/RealMongo.scala
@@ -51,7 +51,7 @@ object RealMongo {
         case Nil => sys.error("""MongoServers are not configured. Configure the value 'servers'. Format is '["host1:port1", "host2:port2", ...]'""")
       }
 
-      if (config[Boolean]("slaveOk", true)) { underlying.setReadPreference(ReadPreference.SECONDARY) } else { underlying.setReadPreference(ReadPreference.PRIMARY) }
+      if (config[Boolean]("slaveOk", true)) { underlying.setReadPreference(ReadPreference.secondary()) } else { underlying.setReadPreference(ReadPreference.primary()) }
 
       underlying
     }


### PR DESCRIPTION
Using a fixed port has ended up with port stomping between parallel
users of RealMongoSpecSupport
