### PR TITLE
Blueeyes services now always prefix their paths with service name/version

### DIFF
--- a/bkka/src/test/resources/logback-test.xml
+++ b/bkka/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender" append="false">
+    <file>target/testlog.log</file>
+
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="trace">
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>

--- a/core/src/main/scala/blueeyes/core/http/test/HttpRequestMatchers.scala
+++ b/core/src/main/scala/blueeyes/core/http/test/HttpRequestMatchers.scala
@@ -6,11 +6,12 @@ import org.specs2.mutable.Specification
 import org.specs2.matcher._
 import akka.dispatch.Future
 import akka.dispatch.ExecutionContext
+import akka.util.Duration
 
 trait HttpRequestMatchers extends Specification with FutureMatchers {
-  case class succeedWithContent[A](matcher: Matcher[A]) extends Matcher[Future[HttpResponse[A]]] {
+  case class succeedWithContent[A](matcher: Matcher[A])(implicit await: Duration = Duration(10, "seconds")) extends Matcher[Future[HttpResponse[A]]] {
     def apply[B <: Future[HttpResponse[A]]](expectable: Expectable[B]): MatchResult[B] = {
-      val nested = whenDelivered[HttpResponse[A]] {
+      val nested = awaited[HttpResponse[A]](await) {
         beLike {
           case HttpResponse(status, _, Some(content), _) => 
             (status.code must_== HttpStatusCodes.OK) and

--- a/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
@@ -11,6 +11,8 @@ import akka.dispatch.ExecutionContext
 import blueeyes.json._
 import blueeyes.util.metrics.DataSize
 
+import com.weiglewilczek.slf4s.Logger
+
 import scala.xml.NodeSeq
 import scalaz.Validation
 import scalaz.Semigroup
@@ -19,6 +21,9 @@ import scalaz.Semigroup
 trait HttpRequestHandlerCombinators {
   implicit def service[A, B](handler: HttpServiceHandler[A, B]): HttpService[A, B] = 
     new HttpHandlerService(handler, identity[A])
+
+  def debug[A, B](logger: Logger): HttpService[A, B] => HttpService[A, B] =
+    (h: HttpService[A, B]) => new DebugService[A, B](logger, h)
 
   /** The path combinator creates a handler that is defined only for suffixes
    * of the specified path pattern.
@@ -304,6 +309,7 @@ trait HttpRequestHandlerCombinators {
   def decodeUrl[A, B](h: HttpService[A, B]) = new DecodeUrlService[A, B](h)
 }
 
+object HttpRequestHandlerCombinators extends HttpRequestHandlerCombinators
 
 class IdentifierWithDefault[A, B](val identifier: A, dflt: => Option[B]) {
   lazy val default = dflt

--- a/core/src/main/scala/blueeyes/core/service/ServiceBuilder.scala
+++ b/core/src/main/scala/blueeyes/core/service/ServiceBuilder.scala
@@ -7,6 +7,8 @@ import akka.dispatch.ExecutionContext
 import blueeyes.bkka.Stoppable
 import blueeyes.core.http._
 
+import com.weiglewilczek.slf4s.Logging
+
 /**
 val emailService = {
   service("email", "1.23") { context =>
@@ -39,7 +41,21 @@ trait ServiceBuilder[T] {
       val name = sname
       val version = sversion
       val desc = sdesc
-      def lifecycle(context: ServiceContext) = slifecycle(context)
+
+      def lifecycle(context: ServiceContext) = {
+        import HttpRequestHandlerCombinators._
+
+        // Service paths are always prefixed by service name and major version string.
+        val ServiceLifecycle(startup, runningState) = slifecycle(context)
+        ServiceLifecycle(
+          startup, 
+          (s: S) => {
+            val (service, stoppable) = runningState(s)
+            val service0 = path("/%s".format(sname)) { path("/%s".format(sversion.vname)) { service } }
+            (service0, stoppable)
+          }
+        )
+      }
     }
   }
 

--- a/core/src/main/scala/blueeyes/core/service/ServiceVersion.scala
+++ b/core/src/main/scala/blueeyes/core/service/ServiceVersion.scala
@@ -1,6 +1,8 @@
 package blueeyes.core.service
 
-case class ServiceVersion(majorVersion: Int, minorVersion: Int, version: String)
+case class ServiceVersion(majorVersion: Int, minorVersion: Int, version: String) {
+  def vname = "v" + majorVersion
+}
 
 trait ServiceVersionImplicits {
   implicit def fromString(value: String) = {

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender" append="false">
+    <file>target/testlog.log</file>
+
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="trace">
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>

--- a/core/src/test/scala/blueeyes/core/service/HttpServerSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/HttpServerSpec.scala
@@ -100,7 +100,7 @@ class HttpServerSpec extends Specification with FutureMatchers {
   "HttpServer.apply" should {
     "delegate to service request handler" in server { 
       case (s, _) =>
-        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/foo/bar")).toOption.get must whenDelivered {
+        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/test/v1/foo/bar")).toOption.get must whenDelivered {
           beLike {
             case HttpResponse(HttpStatus(status, _), headers, Some(content), _) =>
               (status must_== OK) and
@@ -112,7 +112,7 @@ class HttpServerSpec extends Specification with FutureMatchers {
     
     "produce NotFound response when service is not defined for request" in server { 
       case (s, _) =>
-        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/blahblah")).toOption.get must whenDelivered {
+        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/test/v1/blahblah")).toOption.get must whenDelivered {
           beLike {
             case HttpResponse(HttpStatus(HttpStatusCodes.NotFound, _), _, _, _) => ok
           }
@@ -121,7 +121,7 @@ class HttpServerSpec extends Specification with FutureMatchers {
 
     "gracefully handle error-producing service handler" in server { 
       case (s, _) =>
-        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/foo/bar/error")).toOption.get must whenDelivered {
+        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/test/v1/foo/bar/error")).toOption.get must whenDelivered {
           beLike {
             case HttpResponse(HttpStatus(HttpStatusCodes.InternalServerError, _), _, _, _) => ok
           }
@@ -129,7 +129,7 @@ class HttpServerSpec extends Specification with FutureMatchers {
     }
     "gracefully handle dead-future-producing service handler" in server { 
       case (s, _) =>
-        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/foo/bar/dead")).toOption.get must whenDelivered {
+        s.service(HttpRequest[ByteChunk](HttpMethods.GET, "/test/v1/foo/bar/dead")).toOption.get must whenDelivered {
           beLike {
             case HttpResponse(HttpStatus(HttpStatusCodes.InternalServerError, _), _, _, _) => ok
           }

--- a/core/src/test/scala/blueeyes/core/service/ServerHealthMonitorServiceSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/ServerHealthMonitorServiceSpec.scala
@@ -16,7 +16,7 @@ class ServerHealthMonitorServiceSpec extends BlueEyesServiceSpecification with S
 
    "Server Health Monitor Service" should{
     "get server health" in {
-      client.get[JValue]("/blueeyes/server/health") must succeedWithContent {
+      client.get[JValue]("/serverhealth/v1/blueeyes/server/health") must succeedWithContent {
         (content: JValue) => {
           (content \ "runtime" must_!=(JUndefined)) and
           (content \ "memory" must_!=(JUndefined)) and

--- a/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServerNettySpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServerNettySpec.scala
@@ -171,9 +171,9 @@ class HttpServerNettySpec extends Specification with TestAkkaDefaults with HttpR
     Await.result(ByteChunk.forceByteArray(chunk).map(new String(_, "UTF-8")), 10.seconds)
   }
 
-  private def client    = new LocalClient(config).protocol("http").host("localhost").port(port)
+  private def client    = new LocalClient(config).protocol("http").host("localhost").port(port).path("/sample/v1")
 
-  private def sslClient = new LocalClient(config).protocol("https").host("localhost").port(port + 1)
+  private def sslClient = new LocalClient(config).protocol("https").host("localhost").port(port + 1).path("/sample/v1")
 }
 
 class SampleServer extends BlueEyesServer with TestEngineService with TestAkkaDefaults {

--- a/core/src/test/scala/blueeyes/core/service/test/BlueEyesServiceSpecificationSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/test/BlueEyesServiceSpecificationSpec.scala
@@ -27,16 +27,16 @@ class BlueEyesServiceSpecificationSpec extends BlueEyesServiceSpecification with
 
   "Service Specification" should {
     "support get by valid URL" in {
-      client.get[String]("/bar/id/bar.html") must whenDelivered { be_==(serviceResponse) }
+      client.get[String]("/sample/v1/bar/id/bar.html") must whenDelivered { be_==(serviceResponse) }
     }
 
     "support asynch get by valid URL" in {
-      val result = client.get[String]("/asynch/future") 
+      val result = client.get[String]("/sample/v1/asynch/future") 
       result must whenDelivered { be_==(serviceResponse) }
     }
 
     "support eventually asynch get by valid URL" in {
-      client.get[String]("/asynch/eventually") must eventually { whenDelivered { be_==(serviceResponse) } }
+      client.get[String]("/sample/v1/asynch/eventually") must eventually { whenDelivered { be_==(serviceResponse) } }
     }
   }
 }

--- a/json/src/test/resources/logback-test.xml
+++ b/json/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender" append="false">
+    <file>target/testlog.log</file>
+
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="trace">
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>

--- a/mongo/src/test/resources/logback-test.xml
+++ b/mongo/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender" append="false">
+    <file>target/testlog.log</file>
+
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="trace">
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -75,7 +75,8 @@ object BlueEyesBuild extends Build {
       "org.scalaz"         %% "scalaz-core"   % scalazVersion,
       "org.scalaz"         %% "scalaz-effect" % scalazVersion,
       "org.specs2"         %% "specs2"        % "1.12.3"         % "test",
-      "org.scalacheck"     %% "scalacheck"    % "1.10.0"         % "test"
+      "org.scalacheck"     %% "scalacheck"    % "1.10.0"         % "test",
+      "ch.qos.logback"     %  "logback-classic"    % "1.0.0" % "test"
     ),
 
     scalacOptions ++= Seq("-deprecation", "-unchecked")

--- a/util/src/test/resources/logback-test.xml
+++ b/util/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender" append="false">
+    <file>target/testlog.log</file>
+
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="trace">
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>


### PR DESCRIPTION
Also added test logging configuration and dependencies, as well as a debug combinator for easy logging of request bodies.
