### PR TITLE
Fix incorrect format option.

### DIFF
--- a/json/src/main/scala/blueeyes/json/JValue.scala
+++ b/json/src/main/scala/blueeyes/json/JValue.scala
@@ -807,7 +807,7 @@ object JString {
         case '\t' => sb.append("\\t")
         case c =>
           if (c < ' ')
-            sb.append("\\u%04x" format c)
+            sb.append("\\u%04x" format c.toInt)
           else
             sb.append(c)
       }


### PR DESCRIPTION
Rendering of json strings was passing control characters to a %x
formatting string, but %x only accepts Int, not Char, resulting
in an expression being thrown.
