### PR TITLE
Remove race-condition in UpstreamHandler.

### DIFF
--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
@@ -150,10 +150,9 @@ private[engines] class HttpServiceUpstreamHandler(service: AsyncHttpService[Byte
 
   private def killPending(why: Throwable) {
     // Kill all pending responses to this channel:
-    pendingResponses.foreach { pr =>
-      if (!pr.isCompleted) {
-        pr.asInstanceOf[Promise[HttpResponse[ByteChunk]]].failure(why)
-      }
+    pendingResponses.foreach {
+      case (pr: Promise[_]) => pr.tryComplete(Left(why))
+      case _ => // This shouldn't happen.
     }
     pendingResponses.clear()
   }


### PR DESCRIPTION
We were checking if the future was complete, then explicitly pushing a
failure into if it was not. However, there was a race condition between
the check and the call to failure. This now uses Promise's tryComplete
method instead, which can take a failure too.

PLATFORM-1068 #finish
