### PR TITLE
Add extra headers required for CORS

### DIFF
--- a/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
+++ b/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
@@ -81,6 +81,11 @@ object HttpHeaderField {
     `X-Forwarded-Proto`,
     `X-Powered-By`,
     `Access-Control-Allow-Origin`,
+    `Access-Control-Max-Age`,
+    `Access-Control-Allow-Credentials`,
+    `Access-Control-Allow-Methods`,
+    `Access-Control-Allow-Headers`,
+    Origin,
     `Access-Control-Request-Method`,
     `Access-Control-Request-Headers`
   )
@@ -662,6 +667,46 @@ object HttpHeaders {
     def value = origin
   }
   implicit case object `Access-Control-Allow-Origin` extends HttpHeaderField[`Access-Control-Allow-Origin`] {
+    override def parse(s: String) = Some(apply(s))
+    def unapply(t: (String, String)) = parse(t).map(_.origin)
+  }
+
+  case class `Access-Control-Max-Age`(maxAge: Long) extends HttpHeaderResponse {
+    def value = maxAge.toString
+  }
+  implicit case object `Access-Control-Max-Age` extends HttpHeaderField[`Access-Control-Max-Age`] {
+    override def parse(s: String) = s.parseLong.toOption.map(apply)
+    def unapply(t: (String, String)) = parse(t).map(_.maxAge)
+  }
+
+  case class `Access-Control-Allow-Credentials`(allow: Boolean) extends HttpHeaderRequest with HttpHeaderResponse {
+    def value = allow.toString
+  }
+  implicit case object `Access-Control-Allow-Credentials` extends HttpHeaderField[`Access-Control-Allow-Credentials`] {
+    override def parse(s: String) = s.parseBoolean.toOption.map(apply)
+    def unapply(t: (String, String)) = parse(t).map(_.allow)
+  }
+
+  case class `Access-Control-Allow-Methods`(methods: HttpMethod*) extends HttpHeaderResponse {
+    def value = methods.map(_.toString).mkString(",")
+  }
+  implicit case object `Access-Control-Allow-Methods` extends HttpHeaderField[`Access-Control-Allow-Methods`] {
+    override def parse(s: String) = Some(apply(HttpMethods.parseHttpMethods(s): _*))
+    def unapply(t: (String, String)) = parse(t).map(_.methods)
+  }
+
+  case class `Access-Control-Allow-Headers`(fields: HttpHeaderField[_]*) extends HttpHeaderResponse {
+    def value = fields.map(_.toString).mkString(",")
+  }
+  implicit case object `Access-Control-Allow-Headers` extends HttpHeaderField[`Access-Control-Allow-Headers`] {
+    override def parse(s: String) = Some(apply(HttpHeaderField.parseAll(s, "accessControl"): _*))
+    def unapply(t: (String, String)) = parse(t).map(_.fields)
+  }
+
+  case class Origin(origin: String) extends HttpHeaderRequest {
+    def value = origin
+  }
+  implicit case object Origin extends HttpHeaderField[Origin] {
     override def parse(s: String) = Some(apply(s))
     def unapply(t: (String, String)) = parse(t).map(_.origin)
   }

--- a/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
+++ b/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
@@ -93,7 +93,7 @@ object HttpHeaderField {
   val ByName: Map[String, HttpHeaderField[_]] = All.map(v => (v.name.toLowerCase -> v)).toMap
 
   def parseAll(inString: String, parseType: String): List[HttpHeaderField[_]] = {
-    val fields = inString.toLowerCase.split("""\s*,\s*""").toList.flatMap(HttpHeaderField.ByName.get)
+    val fields = inString.trim.toLowerCase.split("""\s*,\s*""").toList.flatMap(HttpHeaderField.ByName.get)
 
     if (parseType == "trailer") fields.filterNot {
       case Trailer => true
@@ -675,7 +675,7 @@ object HttpHeaders {
     def value = maxAge.toString
   }
   implicit case object `Access-Control-Max-Age` extends HttpHeaderField[`Access-Control-Max-Age`] {
-    override def parse(s: String) = s.parseLong.toOption.map(apply)
+    override def parse(s: String) = s.trim.parseLong.toOption.map(apply)
     def unapply(t: (String, String)) = parse(t).map(_.maxAge)
   }
 
@@ -683,7 +683,7 @@ object HttpHeaders {
     def value = allow.toString
   }
   implicit case object `Access-Control-Allow-Credentials` extends HttpHeaderField[`Access-Control-Allow-Credentials`] {
-    override def parse(s: String) = s.parseBoolean.toOption.map(apply)
+    override def parse(s: String) = s.trim.toLowerCase.parseBoolean.toOption.map(apply)
     def unapply(t: (String, String)) = parse(t).map(_.allow)
   }
 
@@ -707,7 +707,7 @@ object HttpHeaders {
     def value = origin
   }
   implicit case object Origin extends HttpHeaderField[Origin] {
-    override def parse(s: String) = Some(apply(s))
+    override def parse(s: String) = Some(apply(s.trim))
     def unapply(t: (String, String)) = parse(t).map(_.origin)
   }
 

--- a/core/src/test/scala/blueeyes/core/http/HttpHeadersSpec.scala
+++ b/core/src/test/scala/blueeyes/core/http/HttpHeadersSpec.scala
@@ -32,4 +32,60 @@ class HttpHeadersSpec extends Specification{
       HttpHeader(("Blargh" -> "foo")) must_== CustomHeader("Blargh", "foo")
     }
   }
+
+  // CORS headers:
+
+  "Access-Control-Max-Age" should {
+    "accept an long" in {
+      `Access-Control-Max-Age`(123L).value mustEqual "123"
+    }
+    "be parseable" in {
+      HttpHeader(("Access-Control-Max-Age", "123")) mustEqual `Access-Control-Max-Age`(123L)
+      HttpHeader(("access-control-max-age", "234")) mustEqual `Access-Control-Max-Age`(234L)
+    }
+  }
+
+  "Access-Control-Allow-Credentials" should {
+    "accept a boolean" in {
+      `Access-Control-Allow-Credentials`(true).value mustEqual "true"
+      `Access-Control-Allow-Credentials`(false).value mustEqual "false"
+    }
+    "be parseable" in {
+      HttpHeader(("Access-Control-Allow-Credentials", "true")) mustEqual `Access-Control-Allow-Credentials`(true)
+      HttpHeader(("access-control-allow-credentials", "FALse ")) mustEqual `Access-Control-Allow-Credentials`(false)
+    }
+  }
+
+  "Access-Control-Allow-Methods" should {
+    import HttpMethods._
+    "accept methods" in {
+      `Access-Control-Allow-Methods`(GET).value mustEqual "GET"
+      `Access-Control-Allow-Methods`(GET, POST).value mustEqual "GET,POST"
+    }
+    "be parseable" in {
+      HttpHeader(("Access-Control-Allow-Methods", "GET")) mustEqual `Access-Control-Allow-Methods`(GET)
+      HttpHeader(("access-control-allow-methods", "Get , post ")) mustEqual `Access-Control-Allow-Methods`(GET, POST)
+    }
+  }
+
+  "Access-Control-Allow-Headers" should {
+    "accept headers" in {
+      `Access-Control-Allow-Headers`(`Content-Type`).value mustEqual "Content-Type"
+      `Access-Control-Allow-Headers`(`Content-Type`, Authorization).value mustEqual "Content-Type,Authorization"
+    }
+    "be parseable" in {
+      HttpHeader(("Access-Control-Allow-Headers", "content-type")) mustEqual `Access-Control-Allow-Headers`(`Content-Type`)
+      HttpHeader(("access-control-allow-headers", "content-type , AUTHORIZATION ")) mustEqual `Access-Control-Allow-Headers`(`Content-Type`, Authorization)
+    }
+  }
+
+  "Origin" should {
+    "accept a boolean" in {
+      Origin("example.com").value mustEqual "example.com"
+    }
+    "be parseable" in {
+      HttpHeader(("Origin", "example.com")) mustEqual Origin("example.com")
+      HttpHeader(("origin", "example.com")) mustEqual Origin("example.com")
+    }
+  }
 }


### PR DESCRIPTION
Add the following HTTP headers required for CORS:
- Access-Control-Max-Age
- Access-Control-Allow-Credentials
- Access-Control-Allow-Methods
- Access-Control-Allow-Headers
- Origin

Definitions taken from the [Mozilla documentation](https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS).
