### PR TITLE
Update Netty to version 3.6.3.Final & make Netty exception handlers safer.

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
   "commons-codec"               % "commons-codec"       % "1.5",
   "javolution"                  % "javolution"          % "5.5.1",
   "joda-time"                   % "joda-time"           % "1.6.2",
-  "org.jboss.netty"             % "netty"               % "3.2.6.Final",
+  "io.netty"                    % "netty"               % "3.6.3.Final",
   "org.streum"                  %%  "configrity-core"   % "0.10.2",
   "org.xlightweb"               % "xlightweb"           % "2.13.2",
   "javax.servlet"               % "javax.servlet-api"   % "3.0.1"           % "provided",

--- a/core/src/test/scala/blueeyes/core/service/engines/netty/HttpNettyChunkedRequestHandlerSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/engines/netty/HttpNettyChunkedRequestHandlerSpec.scala
@@ -101,7 +101,7 @@ class HttpNettyChunkedRequestHandlerSpec extends Specification with Mockito with
       context.getChannel() returns channel
       nettyRequest.setChunked(false)
 
-      handler.messageReceived(context, invalidEvent) must throwA[HttpException]("URLDecoder: Incomplete trailing escape \\(%\\) pattern")
+      handler.messageReceived(context, invalidEvent) must throwA[HttpException]("partial escape sequence at end of string: %1")
     }
   }
 


### PR DESCRIPTION
Adds an additional layer of try/catch to prevent bad behavior potentially caused by exceptions being thrown in an exception handler.
