### PR TITLE
Fixed JObject comparison with null fields

### DIFF
--- a/json/src/main/scala/blueeyes/json/JValue.scala
+++ b/json/src/main/scala/blueeyes/json/JValue.scala
@@ -942,7 +942,14 @@ case class JObject(fields: Map[String, JValue]) extends JValue {
   }
 
   override def equals(other: Any) = other match {
-    case o: JObject => fieldsEq(fields, o.fields)
+    case o: JObject => {
+      if (fields == null)
+        o.fields == null
+      else if (o.fields == null)
+        fields == null
+      else
+        fieldsEq(fields, o.fields)
+    }
     case _ => false
   }
 

--- a/json/src/test/scala/blueeyes/json/JObjectSpec.scala
+++ b/json/src/test/scala/blueeyes/json/JObjectSpec.scala
@@ -6,6 +6,12 @@ class JObjectSpec extends Specification{
   "JObjects equal even fields order is different" in {
     JParser.parseUnsafe(j1) mustEqual(JParser.parseUnsafe(j2))
   }
+  
+  "JObjects equal even with null fields" in {
+    JObject(null: Map[String,blueeyes.json.JValue]) mustNotEqual JParser.parseUnsafe(j1)
+    JParser.parseUnsafe(j1) mustNotEqual JObject(null: Map[String,blueeyes.json.JValue])
+    JObject(null: Map[String,blueeyes.json.JValue]) mustEqual JObject(null: Map[String,blueeyes.json.JValue])
+  }
 
   val j1 = """{
   "eSzgqekhuzwtceLxkkwysoqKig499526":[[null]],


### PR DESCRIPTION
No idea where the null fields are coming from, but this makes it so that things don't crash when it happens (fixes random build failure issues with scalacheck-generated JObjects).
