### PR TITLE
accept combinator now filters on content-type

### DIFF
--- a/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
@@ -204,15 +204,15 @@ trait HttpRequestHandlerCombinators {
    * that have the specified content type. Requires an implicit function
    * used for transcoding.
    */
-  def accept[A, B, A0](mimeType: MimeType)(h: HttpService[Future[A], Future[HttpResponse[B]]])(implicit f: A0 => Future[A]): HttpService[A0, Future[HttpResponse[B]]] = 
-    new AcceptService[A, B, A0](mimeType, h)
+  def accept[A, B, A0](mimeTypes: MimeType*)(h: HttpService[Future[A], Future[HttpResponse[B]]])(implicit f: A0 => Future[A]): HttpService[A0, Future[HttpResponse[B]]] = 
+    new AcceptService[A, B, A0](mimeTypes, h)
 
   /** The accept combinator creates a handler that is defined only for requests
    * that have the specified content type. Requires an implicit function
    * used for transcoding.
    */
-  def accept2[A, B, A0, E1](mimeType: MimeType)(h: HttpService[Future[A], E1 => Future[HttpResponse[B]]])(implicit f: A0 => Future[A]) = 
-    new Accept2Service[A, B, A0, E1](mimeType, h)
+  def accept2[A, B, A0, E1](mimeTypes: MimeType*)(h: HttpService[Future[A], E1 => Future[HttpResponse[B]]])(implicit f: A0 => Future[A]) = 
+    new Accept2Service[A, B, A0, E1](mimeTypes, h)
 
   /** The produce combinator creates a handler that is produces responses
    * that have the specified content type. Requires an implicit function

--- a/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
@@ -222,7 +222,7 @@ trait HttpRequestHandlerCombinators {
     new ProduceService(mimeType, h, f)
 
   /** The produce combinator creates a handler that is produces responses
-   * that have the specified content type. Requires an implicit bijection
+   * that have the specified content type. Requires an implicit function
    * used for transcoding.
    */
   def produce2[A, B, B0, E1](mimeType: MimeType)(h: HttpService[A, E1 => Future[HttpResponse[B]]])(implicit f: B => B0): HttpService[A, E1 => Future[HttpResponse[B0]]] = 

--- a/core/src/main/scala/blueeyes/core/service/HttpServices.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServices.scala
@@ -201,29 +201,29 @@ extends DelegatingService[A, Future[HttpResponse[A]], Future[B], Future[HttpResp
   val metadata = NoMetadata
 }
 
-class AcceptService[T, S, U](mimeType: MimeType, val delegate: HttpService[Future[T], Future[HttpResponse[S]]])(implicit f: U => Future[T]) 
+class AcceptService[T, S, U](mimeTypes: Seq[MimeType], val delegate: HttpService[Future[T], Future[HttpResponse[S]]])(implicit f: U => Future[T]) 
 extends DelegatingService[U, Future[HttpResponse[S]], Future[T], Future[HttpResponse[S]]] {
   import AcceptService._
-  val service = (r: HttpRequest[U]) => convert(mimeType, r, inapplicable) flatMap { newRequest: HttpRequest[Future[T]] => 
+  val service = (r: HttpRequest[U]) => convert(mimeTypes.toSet, r, inapplicable) flatMap { newRequest: HttpRequest[Future[T]] => 
     delegate.service(newRequest) map { checkConvert(newRequest, _) } 
   }
 
-  val metadata = RequestHeaderMetadata(Right(`Content-Type`(mimeType))) 
+  val metadata = RequestHeaderMetadata(Right(`Content-Type`(mimeTypes: _*))) 
 }
 
-class Accept2Service[T, S, U, E1](mimeType: MimeType, val delegate: HttpService[Future[T], E1 => Future[HttpResponse[S]]])(implicit f: U => Future[T]) 
+class Accept2Service[T, S, U, E1](mimeTypes: Seq[MimeType], val delegate: HttpService[Future[T], E1 => Future[HttpResponse[S]]])(implicit f: U => Future[T]) 
 extends DelegatingService[U, E1 => Future[HttpResponse[S]], Future[T], E1 => Future[HttpResponse[S]]] {
   import AcceptService._
-  val service = (r: HttpRequest[U]) => convert(mimeType, r, inapplicable) flatMap { newRequest: HttpRequest[Future[T]] =>
+  val service = (r: HttpRequest[U]) => convert(mimeTypes.toSet, r, inapplicable) flatMap { newRequest: HttpRequest[Future[T]] =>
     delegate.service(newRequest).map(function => (e: E1) => function.apply(e))
   }
 
-  val metadata = RequestHeaderMetadata(Right(`Content-Type`(mimeType))) 
+  val metadata = RequestHeaderMetadata(Right(`Content-Type`(mimeTypes: _*))) 
 }
 
 object AcceptService extends blueeyes.bkka.AkkaDefaults {
-  def convert[U, T](mimeType: MimeType, r: HttpRequest[U], inapplicable: => Inapplicable)(implicit f: U => Future[T]) = {
-    r.mimeTypes.find(_ == mimeType).map(_ => r.copy(content = r.content.map(f)).success).getOrElse(inapplicable.failure)
+  def convert[U, T](mimeTypes: Set[MimeType], r: HttpRequest[U], inapplicable: => Inapplicable)(implicit f: U => Future[T]) = {
+    r.mimeTypes.find(mimeTypes).map(_ => r.copy(content = r.content.map(f)).success).getOrElse(inapplicable.failure)
   }
 
   def checkConvert[T, S](request: HttpRequest[Future[T]], response: Future[HttpResponse[S]]) = {

--- a/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandlerSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandlerSpec.scala
@@ -92,6 +92,7 @@ class HttpServiceUpstreamHandlerSpec extends Specification with Mockito with Log
     val stateEvent   = mock[ChannelStateEvent]
     val exceptionEvent = new DefaultExceptionEvent(channel, HttpException(HttpStatusCodes.BadRequest, "bad mojo"))
 
+    channel.isOpen() returns true
     channel.isConnected() returns true
     context.getChannel() returns channel
 


### PR DESCRIPTION
Previously, we didn't have any combinator that allowed the server to dispatch based upon content type, though this seemed the obvious thing for the accept combinator to do. Now it does so.
