### PR TITLE
Undo isOpen check in channel handler

### DIFF
--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
@@ -130,7 +130,7 @@ private[engines] class HttpServiceUpstreamHandler(service: AsyncHttpService[Byte
     val nettyResponse = new DefaultHttpResponse(toNettyVersion(response.version), toNettyStatus(response.status))
     for (header <- response.headers.raw) nettyResponse.setHeader(header._1, header._2)
 
-    if (channel.isOpen && channel.isConnected) {
+    if (channel.isConnected) {
       val nettyFuture = response.content match {
         case Some(Left(buffer)) =>
           nettyResponse.setHeader(NettyHttpHeaders.Names.CONTENT_LENGTH, buffer.remaining.toString)


### PR DESCRIPTION
Never mind that isConnected returns true while isOpen returns false, it's causing responses to hang.
