### PR TITLE
Add failFast option to AsyncParser.

### DIFF
--- a/json/src/main/scala/blueeyes/json/JParser.scala
+++ b/json/src/main/scala/blueeyes/json/JParser.scala
@@ -53,6 +53,7 @@ object JParser {
   def parseManyFromByteBuffer(buf: ByteBuffer): Result[Seq[JValue]] =
     fromTryCatch(new ByteBufferParser(buf).parseMany())
 
+  @deprecated("Use the AsyncParser() factory constructor instead.", "1.0")
   def parseAsync(buf: ByteBuffer): AsyncResult =
-    AsyncParser().feed(Some(buf))
+    AsyncParser(false).feed(Some(buf))
 }


### PR DESCRIPTION
Previously, an AsyncParser would try to accumulate as many parse
errors as possible using a newline-based error recovery strategy.
This change introduces a failFast Boolean constructor parameter.

When true, an async parsing result will return at most one error,
and no further parsing attempt will be made. When false, the
previous behavior will be used.

Note that the error-recovery is only intended to help users quickly
diagnose and fix bad JSON. The results when using error-recovery
are not well-defined unless users delimit their records with
literal newlines (and do not use literal newlines anywhere else).
