### PR TITLE
Fix HttpException status line overflow

### DIFF
--- a/core/src/main/scala/blueeyes/core/data.scala
+++ b/core/src/main/scala/blueeyes/core/data.scala
@@ -108,7 +108,7 @@ package object data {
           }
 
         case Left(buffer) =>
-          Future(Left(buffer)) // either right type must match
+          Promise successful Left(buffer) // either right type must match
       }
     }
 

--- a/core/src/main/scala/blueeyes/core/http/HttpException.scala
+++ b/core/src/main/scala/blueeyes/core/http/HttpException.scala
@@ -2,12 +2,8 @@ package blueeyes.core.http
 
 import blueeyes.util.RichThrowableImplicits._
 
-case class HttpException(failure: HttpFailure, reason: String) extends Exception(reason) {
-  def status = HttpStatus(failure, reason)
-}
+case class HttpException(failure: HttpFailure, reason: String) extends Exception(reason) 
 
 object HttpException {
   def apply(failure: HttpFailure): HttpException = new HttpException(failure, failure.defaultMessage)
-  
-  def apply(failure: HttpFailure, cause: Throwable): HttpException = new HttpException(failure, cause.getMessage)
 }

--- a/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
+++ b/core/src/main/scala/blueeyes/core/http/HttpHeader.scala
@@ -161,13 +161,14 @@ trait HttpHeadersImplicits extends HttpHeaderImplicits {
 }
 
 object HttpHeaders {
-  def apply(i: Iterable[(String, String)]): HttpHeaders = {
-    new HttpHeaders(i.map(HttpHeader(_).tuple)(collection.breakOut))
-  }
+  def apply(headers: HttpHeader*): HttpHeaders = 
+    apply(headers.map(_.tuple))
+    
+  def apply(i: Iterable[(String, String)]): HttpHeaders = 
+    apply(i.map(HttpHeader(_)))
 
-  def apply[A](i: Iterable[A])(implicit ev: A <:< HttpHeader): HttpHeaders = {
+  def apply[A](i: Iterable[A])(implicit ev: A <:< HttpHeader): HttpHeaders = 
     new HttpHeaders(i.map(ev(_).tuple)(collection.breakOut))
-  }
 
   val Empty: HttpHeaders = new HttpHeaders(Map.empty[String, String])
 

--- a/core/src/main/scala/blueeyes/core/http/HttpResponse.scala
+++ b/core/src/main/scala/blueeyes/core/http/HttpResponse.scala
@@ -1,8 +1,9 @@
 package blueeyes.core.http
 
 import blueeyes.core.http.HttpStatusCodes._
+import blueeyes.core.http.HttpHeaders._
+import blueeyes.core.http.MimeTypes._
 import blueeyes.core.http.HttpVersions._
-import com.weiglewilczek.slf4s.Logging
 
 sealed case class HttpResponse[+T](
   status: HttpStatus = HttpStatus(OK), 
@@ -16,9 +17,9 @@ sealed case class HttpResponse[+T](
 object HttpResponse {
   def empty[T] = HttpResponse[T](content = None)
 
-  def apply[T](th: Throwable): HttpResponse[T] = th match {
-    case e: HttpException => HttpResponse[T](HttpStatus(e.failure, e.reason))
-    case e => HttpResponse[T](HttpStatus(HttpStatusCodes.InternalServerError, Option(e.getMessage).getOrElse("")))
+  def error[T](th: Throwable)(implicit decode: String => T): HttpResponse[T] = th match {
+    case e: HttpException => HttpResponse[T](HttpStatus(e.failure), headers = HttpHeaders(`Content-Type`(text/plain)), content = Some(decode(e.reason)))
+    case e => HttpResponse[T](HttpStatus(HttpStatusCodes.InternalServerError))
   }
 }
 

--- a/core/src/main/scala/blueeyes/core/service/HttpServerModule.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServerModule.scala
@@ -7,8 +7,12 @@ import akka.dispatch.Promise
 import akka.dispatch.ExecutionContext
 import akka.util.Timeout
 
-import blueeyes.core.data.ByteChunk
+import blueeyes.core.data._
 import blueeyes.core.http._
+import blueeyes.core.http.HttpStatusCodes._
+import blueeyes.core.http.HttpStatusImplicits._
+import blueeyes.core.http.HttpHeaders._
+import blueeyes.core.http.MimeTypes._
 import blueeyes.core.service._
 import blueeyes.util.RichThrowableImplicits._
 import blueeyes.util.CommandLineArguments
@@ -129,12 +133,10 @@ abstract class HttpServerLike(val rootConfig: Configuration) extends HttpServerC
   }
 
   def trapErrors(delegate: AsyncHttpService[ByteChunk]): AsyncHttpService[ByteChunk] = new CustomHttpService[ByteChunk, Future[HttpResponse[ByteChunk]]] {
-    private def convertErrorToResponse(th: Throwable): HttpResponse[ByteChunk] = th match {
-      case e: HttpException => HttpResponse[ByteChunk](HttpStatus(e.failure, e.reason))
-      case e => {
-        log.error("Error handling request", e)
-        HttpResponse[ByteChunk](HttpStatus(HttpStatusCodes.InternalServerError, Option(e.getMessage).getOrElse("")))
-      }
+    private def convertErrorToResponse(request: HttpRequest[ByteChunk], th: Throwable): HttpResponse[ByteChunk] = {
+      import DefaultBijections._
+      log.error("Error handling request " + request.shows, th)
+      HttpResponse.error[ByteChunk](th)
     }
 
     val service = (r: HttpRequest[ByteChunk]) => {
@@ -144,17 +146,21 @@ abstract class HttpServerLike(val rootConfig: Configuration) extends HttpServerC
       } catch {
         // An error during invocation of the request handler, convert to
         // proper response:
-        case error: Throwable => success(Promise.successful(convertErrorToResponse(error)))
+        case error: Throwable => success(Promise.successful(convertErrorToResponse(r, error)))
       }
 
       // Convert the raw future into one that cannot die:
       rawValidation match {
-        case Success(rawFuture) => success((rawFuture recover { case error => convertErrorToResponse(error) }))
-        case Failure(DispatchError(throwable)) => success(Future(convertErrorToResponse(throwable)))
-        case failure => 
-          val message = "No handler could be found for your request: " + r.show
+        case Success(rawFuture) => success((rawFuture recover { case error => convertErrorToResponse(r, error) }))
+        case Failure(DispatchError(throwable)) => success(Promise.successful(convertErrorToResponse(r, throwable)))
+        case Failure(Inapplicable(services @ _*)) =>
+          val message = "No handler could be found for your request: " + r.shows
           success(
-            Promise.successful(HttpResponse[ByteChunk](HttpStatus(HttpStatusCodes.NotFound, message)))
+            Promise.successful(
+              HttpResponse[ByteChunk](NotFound, 
+                                      headers = HttpHeaders(`Content-Type`(text/plain)), 
+                                      content = Some(DefaultBijections.stringToChunk(message)))
+            )
           )
       }
     }

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpNettyChunkedRequestHandler.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpNettyChunkedRequestHandler.scala
@@ -60,8 +60,7 @@ private[engines] class HttpNettyChunkedRequestHandler(chunkSize: Int)(implicit e
           }
         }
 
-        try Channels.fireMessageReceived(ctx, httpRequestBuilder(content), event.getRemoteAddress)
-        catch { case ex: IllegalArgumentException => throw HttpException(HttpStatusCodes.BadRequest, ex) }
+        Channels.fireMessageReceived(ctx, httpRequestBuilder(content), event.getRemoteAddress)
 
       case chunk: NettyChunk =>
         val current = chain

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
@@ -78,7 +78,7 @@ private[engines] class HttpServiceUpstreamHandler(service: AsyncHttpService[Byte
         }
 
       case Failure(DispatchError(cause)) =>
-        writeResponse(request, ctx.getChannel, HttpResponse(cause))
+        writeResponse(request, ctx.getChannel, HttpResponse.error[ByteChunk](cause))
 
       case Failure(Inapplicable(_)) =>
         writeResponse(request, ctx.getChannel,

--- a/core/src/test/scala/blueeyes/core/service/engines/netty/HttpNettyChunkedRequestHandlerSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/engines/netty/HttpNettyChunkedRequestHandlerSpec.scala
@@ -8,6 +8,7 @@ import akka.dispatch.Await
 import blueeyes.bkka._
 import blueeyes.core.data._
 import blueeyes.core.http.{HttpException, HttpRequest}
+import blueeyes.core.http.HttpStatusCodes._
 
 import org.jboss.netty.buffer.{HeapChannelBufferFactory, ChannelBuffers}
 import org.jboss.netty.channel._
@@ -101,7 +102,9 @@ class HttpNettyChunkedRequestHandlerSpec extends Specification with Mockito with
       context.getChannel() returns channel
       nettyRequest.setChunked(false)
 
-      handler.messageReceived(context, invalidEvent) must throwA[HttpException]("partial escape sequence at end of string: %1")
+      handler.messageReceived(context, invalidEvent) must throwA[HttpException].like {
+        case HttpException(BadRequest, string) => string must startWith("An encoding error")
+      }
     }
   }
 


### PR DESCRIPTION
Previously, error responses generated by HttpException could
overflow the maximum HTTP line length because error messages
were being written into the status line. This change modifies
error handling to always use Content-Type: text/plain for
error responses generated as a result of HttpExceptions (and
other sorts of exceptions) thrown during request processing.

It is important to note that we have to use text/plain since at
the point of handling, no semantic information about the type of
the response is available. So, HttpException should _only_ ever
be used for fatal errors that are not part of the defined API
for a given service.
