### PR TITLE
Fix major problems in the AsyncParser design.

### DIFF
--- a/json/src/main/scala/blueeyes/json/AsyncParser.scala
+++ b/json/src/main/scala/blueeyes/json/AsyncParser.scala
@@ -19,14 +19,30 @@ object AsyncParser {
   @deprecated("Use AsyncParser.stream() to maintain the current behavior", "1.0")
   def apply(): AsyncParser = stream()
 
+  /**
+   * Asynchronous parser for a stream of (whitespace-delimited) JSON values.
+   */
   def stream(): AsyncParser = 
-    new AsyncParser(-1, 0, Nil, new Array[Byte](131072), 0, 131072, 0, false, 0)
+    new AsyncParser(state = -1, curr = 0, stack = Nil,
+      data = new Array[Byte](131072), len = 0, allocated = 131072,
+      offset = 0, done = false, streamMode = 0)
 
+  /**
+   * Asynchronous parser for a single JSON value.
+   */
   def json(): AsyncParser =
-    new AsyncParser(-1, 0, Nil, new Array[Byte](131072), 0, 131072, 0, false, -1)
+    new AsyncParser(state = -1, curr = 0, stack = Nil,
+      data = new Array[Byte](131072), len = 0, allocated = 131072,
+      offset = 0, done = false, streamMode = -1)
 
+  /**
+   * Asynchronous parser which can unwrap a single JSON array into a stream of
+   * values (or return a single value otherwise).
+   */
   def unwrap(): AsyncParser =
-    new AsyncParser(-5, 0, Nil, new Array[Byte](131072), 0, 131072, 0, false, 1)
+    new AsyncParser(state = -5, curr = 0, stack = Nil,
+      data = new Array[Byte](131072), len = 0, allocated = 131072,
+      offset = 0, done = false, streamMode = 1)
 }
 
 // We have a lot of fields here.
@@ -138,9 +154,6 @@ final class AsyncParser protected[json] (
     // accumulates errors and results
     val errors = mutable.ArrayBuffer.empty[ParseException]
     val results = mutable.ArrayBuffer.empty[JValue]
-
-    // FIXME: make sure that array streamer stores whether it is
-    // streaming an array or not.
 
     // we rely on exceptions to tell us when we run out of data
     try {

--- a/json/src/main/scala/blueeyes/json/AsyncParser.scala
+++ b/json/src/main/scala/blueeyes/json/AsyncParser.scala
@@ -45,36 +45,43 @@ object AsyncParser {
       offset = 0, done = false, streamMode = 1)
 }
 
-// We have a lot of fields here.
-// 
-// The (state, curr, stack) triple is used to save and restore parser
-// state between async calls. State also helps encode extra
-// information when streaming or unwrapping an array.
-//
-// The (data, len, allocated) triple is used to manage the underlying
-// data the parser is keeping track of. As new data comes in, data may
-// be expanded if not enough space is available.
-// 
-// The offset parameter is used to drive the outer async parsing. It
-// stores similar information to curr but is kept separate to avoid
-// "corrupting" our snapshot.
-// 
-// The done parameter is used internally to help figure out when the
-// atEof() parser method should return true. This will be set when
-// apply(None) is called.
-// 
-// The streamMode parameter controls how the asynchronous parser will
-// be handling multiple values. There are three states:
-// 
-//    1: An array is being unwrapped. Normal JSON array rules apply
-//       (Note that if the outer value observed is not an array, this
-//       mode will toggle to the -1 mode).
-//
-//    0: A JSON stream is being parsed. JSON values will be separated
-//       by optional whitespace
-//
-//   -1: No streaming is occuring. Only a single JSON value is
-//       allowed.
+/*
+ * AsyncParser is able to parse chunks of data (encoded as
+ * Option[ByteBuffer] instances) and parse asynchronously.  You can
+ * use the factory methods in the companion object to instantiate an
+ * async parser.
+ * 
+ * The async parser's fields are described below:
+ * 
+ * The (state, curr, stack) triple is used to save and restore parser
+ * state between async calls. State also helps encode extra
+ * information when streaming or unwrapping an array.
+ *
+ * The (data, len, allocated) triple is used to manage the underlying
+ * data the parser is keeping track of. As new data comes in, data may
+ * be expanded if not enough space is available.
+ * 
+ * The offset parameter is used to drive the outer async parsing. It
+ * stores similar information to curr but is kept separate to avoid
+ * "corrupting" our snapshot.
+ * 
+ * The done parameter is used internally to help figure out when the
+ * atEof() parser method should return true. This will be set when
+ * apply(None) is called.
+ * 
+ * The streamMode parameter controls how the asynchronous parser will
+ * be handling multiple values. There are three states:
+ * 
+ *    1: An array is being unwrapped. Normal JSON array rules apply
+ *       (Note that if the outer value observed is not an array, this
+ *       mode will toggle to the -1 mode).
+ *
+ *    0: A JSON stream is being parsed. JSON values will be separated
+ *       by optional whitespace
+ *
+ *   -1: No streaming is occuring. Only a single JSON value is
+ *       allowed.
+ */
 final class AsyncParser protected[json] (
   protected[json] var state: Int,
   protected[json] var curr: Int,

--- a/json/src/main/scala/blueeyes/json/AsyncParser.scala
+++ b/json/src/main/scala/blueeyes/json/AsyncParser.scala
@@ -1,6 +1,7 @@
 package blueeyes.json
 
 import scala.annotation.{switch, tailrec}
+import scala.math.max
 import scala.collection.mutable
 import java.nio.ByteBuffer
 
@@ -15,17 +16,59 @@ private[json] class AsyncException extends Exception
 private[json] class FailureException extends Exception
 
 object AsyncParser {
-  def apply(failFast: Boolean): AsyncParser =
-    new AsyncParser(new Array[Byte](131072), 0, 131072, 0, false, failFast)
+  @deprecated("Use AsyncParser.stream() to maintain the current behavior", "1.0")
+  def apply(): AsyncParser = stream()
+
+  def stream(): AsyncParser = 
+    new AsyncParser(-1, 0, Nil, new Array[Byte](131072), 0, 131072, 0, false, 0)
+
+  def json(): AsyncParser =
+    new AsyncParser(-1, 0, Nil, new Array[Byte](131072), 0, 131072, 0, false, -1)
+
+  def unwrap(): AsyncParser =
+    new AsyncParser(-5, 0, Nil, new Array[Byte](131072), 0, 131072, 0, false, 1)
 }
 
+// We have a lot of fields here.
+// 
+// The (state, curr, stack) triple is used to save and restore parser
+// state between async calls. State also helps encode extra
+// information when streaming or unwrapping an array.
+//
+// The (data, len, allocated) triple is used to manage the underlying
+// data the parser is keeping track of. As new data comes in, data may
+// be expanded if not enough space is available.
+// 
+// The offset parameter is used to drive the outer async parsing. It
+// stores similar information to curr but is kept separate to avoid
+// "corrupting" our snapshot.
+// 
+// The done parameter is used internally to help figure out when the
+// atEof() parser method should return true. This will be set when
+// apply(None) is called.
+// 
+// The streamMode parameter controls how the asynchronous parser will
+// be handling multiple values. There are three states:
+// 
+//    1: An array is being unwrapped. Normal JSON array rules apply
+//       (Note that if the outer value observed is not an array, this
+//       mode will toggle to the -1 mode).
+//
+//    0: A JSON stream is being parsed. JSON values will be separated
+//       by optional whitespace
+//
+//   -1: No streaming is occuring. Only a single JSON value is
+//       allowed.
 final class AsyncParser protected[json] (
+  protected[json] var state: Int,
+  protected[json] var curr: Int,
+  protected[json] var stack: List[Context],
   protected[json] var data: Array[Byte],
   protected[json] var len: Int,
   protected[json] var allocated: Int,
-  protected[json] var index: Int,
+  protected[json] var offset: Int,
   protected[json] var done: Boolean,
-  protected[json] val failFast: Boolean
+  protected[json] var streamMode: Int
 ) extends ByteBasedParser {
 
   protected[this] var line = 0
@@ -34,7 +77,7 @@ final class AsyncParser protected[json] (
   protected[this] final def column(i: Int) = i - pos
 
   protected[this] final def copy() =
-    new AsyncParser(data.clone, len, allocated, index, done, failFast)
+    new AsyncParser(state, curr, stack, data.clone, len, allocated, offset, done, streamMode)
 
   final def apply(b: Option[ByteBuffer]): (AsyncParse, AsyncParser) = copy.feed(b)
 
@@ -48,25 +91,43 @@ final class AsyncParser protected[json] (
     // data array. we never shrink the data array, assuming users will call
     // feed with similarly-sized buffers.
     if (need > allocated) {
-      val newdata = new Array[Byte](need)
+      val doubled = if (allocated < 0x40000000) allocated * 2 else Int.MaxValue
+      val newsize = max(need, doubled)
+      val newdata = new Array[Byte](newsize)
       System.arraycopy(data, 0, newdata, 0, len)
       data = newdata
-      allocated = need
+      allocated = newsize
     }
 
     buf.get(data, len, buflen)
     len = need
   }
 
-  // if this runs off the end of at() we'll get an AsyncException, which is OK
-  // as it will signal the end of the parse.
-  protected[json] def recoverFromError(e: ParseException) {
-    if (e.index > index && at(e.index - 1) == '\n') {
-      index = e.index
-    } else {
-      while (at(index) != '\n') index += 1
-    }
-  }
+  // Explanation of the new synthetic states .The parser machinery
+  // uses positive integers for states while parsing json values. We
+  // use these negative states to keep track of the async parser's
+  // status between json values.
+  //
+  // ASYNC_PRESTART: We haven't seen any non-whitespace yet. We
+  // could be parsing an array, or not. We are waiting for valid
+  // JSON.
+  // 
+  // ASYNC_START: We've seen an array and have begun unwrapping
+  // it. We could see a ] if the array is empty, or valid JSON.
+  // 
+  // ASYNC_END: We've parsed an array and seen the final ]. At this
+  // point we should only see whitespace or an EOF.
+  // 
+  // ASYNC_POSTVAL: We just parsed a value from inside the array. We
+  // expect to see whitespace, a comma, or an EOF.
+  // 
+  // ASYNC_PREVAL: We are in an array and we just saw a comma. We
+  // expect to see whitespace or a JSON value.
+  @inline private[this] final def ASYNC_PRESTART = -5
+  @inline private[this] final def ASYNC_START = -4
+  @inline private[this] final def ASYNC_END = -3
+  @inline private[this] final def ASYNC_POSTVAL = -2
+  @inline private[this] final def ASYNC_PREVAL = -1
 
   protected[json] def feed(b: Option[ByteBuffer]): (AsyncParse, AsyncParser) = {
     b match {
@@ -78,65 +139,126 @@ final class AsyncParser protected[json] (
     val errors = mutable.ArrayBuffer.empty[ParseException]
     val results = mutable.ArrayBuffer.empty[JValue]
 
+    // FIXME: make sure that array streamer stores whether it is
+    // streaming an array or not.
+
     // we rely on exceptions to tell us when we run out of data
     try {
       while (true) {
-        (at(index): @switch) match {
-          // just pass whitespace by looking for the next value
-          case '\n' =>
-            newline(index)
-            index += 1
+        if (state < 0) {
+          (at(offset): @switch) match {
+            case '\n' =>
+              newline(offset)
+              offset += 1
 
-          case ' ' | '\t' | '\r' =>
-            index += 1
+            case ' ' | '\t' | '\r' =>
+              offset += 1
 
-          // ok, let's try parsing at this point
-          case _ =>
-            try {
-              index = reset(index)
-              val (value, j) = parse(index)
-              results.append(value)
-              index = j
-            } catch {
-              // we'll catch a parsing exception, note the error, and try to
-              // make an effort to find the next value.
-              case e: ParseException =>
-                errors.append(e)
-                if (failFast) {
-                  throw new AsyncException
+            case '[' =>
+              if (state == ASYNC_PRESTART) {
+                offset += 1
+                state = ASYNC_START
+              } else if (state == ASYNC_END) {
+                die(offset, "expected eof")
+              } else if (state == ASYNC_POSTVAL) {
+                die(offset, "expected , or ]")
+              } else {
+                state = 0
+              }
+
+            case ',' =>
+              if (state == ASYNC_POSTVAL) {
+                offset += 1
+                state = ASYNC_PREVAL
+              } else if (state == ASYNC_END) {
+                die(offset, "expected eof")
+              } else {
+                die(offset, "expected json value")
+              }
+
+            case ']' =>
+              if (state == ASYNC_POSTVAL || state == ASYNC_START) {
+                if (streamMode > 0) {
+                  offset += 1
+                  state = ASYNC_END
                 } else {
-                  recoverFromError(e)
+                  die(offset, "expected json value or eof")
                 }
-            }
+              } else if (state == ASYNC_END) {
+                die(offset, "expected eof")
+              } else {
+                die(offset, "expected json value")
+              }
+
+            case c =>
+              if (state == ASYNC_END) {
+                die(offset, "expected eof")
+              } else if (state == ASYNC_POSTVAL) {
+                die(offset, "expected ] or ,")
+              } else {
+                if (state == ASYNC_PRESTART && streamMode > 0) streamMode = -1
+                state = 0
+              }
+          }
+
+        } else {
+          // jump straight back into rparse
+          offset = reset(offset)
+          val (value, j) = if (state <= 0) {
+            parse(offset)
+          } else {
+            rparse(state, curr, stack)
+          }
+          if (streamMode > 0) {
+            state = ASYNC_POSTVAL
+          } else if (streamMode == 0) {
+            state = ASYNC_PREVAL
+          } else {
+            state = ASYNC_END
+          }
+          curr = j
+          offset = j
+          stack = Nil
+          results.append(value)
         }
       }
     } catch {
       case e: AsyncException =>
-        // we ran out of data. index is storing the last place we started
-        // parsing (or the last place we tried to start parsing) so we can just
-        // return what we have, and resume later.
+        // we ran out of data, so return what we have so far
 
-        // reset() in case we're done with our current buffer
-        index = reset(index)
-
-      case e: Exception =>
-        // we got some other exception
-        throw e
+      case e: ParseException =>
+        // we hit a parser error, so return that error and results so far
+        errors.append(e)
     }
     (AsyncParse(errors, results), this)
   }
 
-  // every 65k bytes we shift our array back by 65k.
+  // every 1M we shift our array back by 1M.
   protected[this] final def reset(i: Int): Int = {
-    if (index >= 65536) {
-      len -= 65536
-      index -= 65536
-      pos -= 65536
-      System.arraycopy(data, 65536, data, 0, len)
-      i - 65536
+    if (offset >= 1048576) {
+      len -= 1048576
+      offset -= 1048576
+      pos -= 1048576
+      System.arraycopy(data, 1048576, data, 0, len)
+      i - 1048576
     } else {
       i
     }
+  }
+
+  /**
+   * We use this to keep track of the last recoverable place we've
+   * seen. If we hit an AsyncException, we can later resume from this
+   * point.
+   *
+   * This method is called during every loop of rparse, and the
+   * arguments are the exact arguments we can pass to rparse to
+   * continue where we left off.
+   */
+  protected[this] final def checkpoint(state: Int, i: Int, stack: List[Context]) {
+    this.state = state
+    this.curr = i
+    this.stack = stack
   }
 
   /**

--- a/json/src/main/scala/blueeyes/json/ByteBasedParser.scala
+++ b/json/src/main/scala/blueeyes/json/ByteBasedParser.scala
@@ -76,7 +76,7 @@ private[json] trait ByteBasedParser extends Parser {
       } else {
         die(j, "invalid UTF-8 encoding")
       }
-      j = reset(j)
+      //j = reset(j)
       c = byte(j)
     }
     ctxt.add(sb.makeString)

--- a/json/src/main/scala/blueeyes/json/ByteBasedParser.scala
+++ b/json/src/main/scala/blueeyes/json/ByteBasedParser.scala
@@ -76,7 +76,6 @@ private[json] trait ByteBasedParser extends Parser {
       } else {
         die(j, "invalid UTF-8 encoding")
       }
-      //j = reset(j)
       c = byte(j)
     }
     ctxt.add(sb.makeString)

--- a/json/src/main/scala/blueeyes/json/ByteBufferParser.scala
+++ b/json/src/main/scala/blueeyes/json/ByteBufferParser.scala
@@ -17,6 +17,7 @@ extends SyncParser with ByteBasedParser {
 
   final def close() { src.position(src.limit) }
   final def reset(i: Int): Int = i
+  final def checkpoint(state: Int, i: Int, stack: List[Context]) {}
   final def byte(i: Int): Byte = src.get(i + start)
   final def at(i: Int): Char = src.get(i + start).toChar
 

--- a/json/src/main/scala/blueeyes/json/ChannelParser.scala
+++ b/json/src/main/scala/blueeyes/json/ChannelParser.scala
@@ -70,6 +70,8 @@ extends SyncParser with ByteBasedParser {
     }
   }
 
+  final def checkpoint(state: Int, i: Int, stack: List[Context]) {}
+
   /**
    * This is a specialized accessor for the case where our underlying data are
    * bytes not chars.

--- a/json/src/main/scala/blueeyes/json/Context.scala
+++ b/json/src/main/scala/blueeyes/json/Context.scala
@@ -21,7 +21,7 @@ private[json] final class SingleContext extends Context {
 }
 
 private[json] final class ArrContext extends Context {
-  private val vs = mutable.ListBuffer.empty[JValue]
+  private val vs = mutable.ArrayBuffer.empty[JValue]
 
   def add(s: String): Unit = vs.append(JString(s))
   def add(v: JValue): Unit = vs.append(v)

--- a/json/src/main/scala/blueeyes/json/Parser.scala
+++ b/json/src/main/scala/blueeyes/json/Parser.scala
@@ -53,6 +53,12 @@ private[json] trait Parser {
   protected[this] def reset(i: Int): Int
 
   /**
+   * The checkpoint() method is used to allow some parsers to store their
+   * progress.
+   */
+  protected[this] def checkpoint(state: Int, i: Int, stack: List[Context]): Unit
+
+  /**
    * Should be called when parsing is finished.
    */
   protected[this] def close(): Unit
@@ -277,6 +283,7 @@ private[json] trait Parser {
   @tailrec
   protected[this] final def rparse(state: Int, j: Int, stack: List[Context]): (JValue, Int) = {
     val i = reset(j)
+    checkpoint(state, i, stack)
     (state: @switch) match {
       // we are inside an object or array expecting to see data
       case DATA => (at(i): @switch) match {

--- a/json/src/main/scala/blueeyes/json/StringParser.scala
+++ b/json/src/main/scala/blueeyes/json/StringParser.scala
@@ -10,11 +10,12 @@ package blueeyes.json
 private[json] final class StringParser(s: String)
 extends SyncParser with CharBasedParser {
   var line = 0
-  protected[this] final def column(i: Int) = i
-  protected[this] final def newline(i: Int) { line += 1 }
-  protected[this] final def reset(i: Int): Int = i
-  protected[this] final def at(i: Int): Char = s.charAt(i)
-  protected[this] final def at(i: Int, j: Int): String = s.substring(i, j)
-  protected[this] final def atEof(i: Int) = i == s.length
-  protected[this] final def close() = ()
+  final def column(i: Int) = i
+  final def newline(i: Int) { line += 1 }
+  final def reset(i: Int): Int = i
+  final def checkpoint(state: Int, i: Int, stack: List[Context]) {}
+  final def at(i: Int): Char = s.charAt(i)
+  final def at(i: Int, j: Int): String = s.substring(i, j)
+  final def atEof(i: Int) = i == s.length
+  final def close() = ()
 }


### PR DESCRIPTION
The async parser was introduced to handle a very specific use case:
parsing a (whitespace delimited) stream of relatively small (<1M) JSON
objects. Its design, buffering strategy, and strategy for resuming
parsing were all based on this scenario. In scenarios where the user
wanted to use many small chunks to parse a much larger value (i.e. 60M)
parser performance would degrate horribly compared to the synchronous
(all-at-once) parser.

Furthermore, the error-recovery strategy was based around similar
assumptions, and was not reliable in general (without frim commitments
from the user about delimiters and escaping it is hard to see how it
could be).

This commit does several things:
1. Fix the major performance problems seen when async parsing one
   large value. While this is still not an ideal situation,
   performance is now roughly on-par with the equivalent sync parser.
2. Remove the error-recovery option for the AsyncParser. It didn't
   work reliably and was not being relied on by anyone.
3. Create 3 different async parsing modes:
   
   a. Streaming: This is the existing behavior (returning a collection
      of whitespace-delimited JSON values).
   
   b. Json: This mode expects the input to be a single well-formed
      JSON value. In the future this should become the default
      behavior.
   
   c. Unwrapping: This mode is like (b) but if the JSON value is an
      array, the parser will instead parse the contents of the array
      as a stream and return those values, rather than the outer
      array.
   
   Mode (c) is especially exciting, since for situations where users
   need to parse very large arrays of values. Unlike the sync parser
   (or the async parser in modes (a) and (b)) unwrapping means that
   the parser itself does not need to accumulate and store all the
   parsed objects itself.
4. The commit adds some additional tests and benchmarks to measure the
   performance of these parsers.

None of the synchronous parsers should be affected by these changes.
