### PR TITLE
Applies the Single Responsibility Principle to blueeyes service combinators

### DIFF
--- a/core/src/main/scala/blueeyes/BlueEyesServer.scala
+++ b/core/src/main/scala/blueeyes/BlueEyesServer.scala
@@ -23,10 +23,8 @@ import com.weiglewilczek.slf4s.Logging
  * </pre>
  */
 trait BlueEyesServer extends NettyEngine with ReflectiveServiceList[ByteChunk] with Logging with HttpServerMain { self =>
-  class HttpServer(rootConfig: Configuration, ctx: ExecutionContext) extends NettyHttpServer(rootConfig, ctx) {
+  class HttpServer(rootConfig: Configuration, ctx: ExecutionContext) extends NettyHttpServer(rootConfig, services, ctx) {
     implicit val executionContext = ctx
-    val services = self.services
-    val log = self.logger
   }
 
   def server(rootConfig: Configuration, ctx: ExecutionContext) = new HttpServer(rootConfig, ctx)

--- a/core/src/main/scala/blueeyes/ServletServer.scala
+++ b/core/src/main/scala/blueeyes/ServletServer.scala
@@ -23,11 +23,9 @@ import com.weiglewilczek.slf4s.Logging
  * </pre>
  */
 
-trait ServletServer extends ServletEngine with ReflectiveServiceList[ByteChunk] with Logging { self =>
-  class HttpServer(rootConfig: Configuration, val executionContext: ExecutionContext) extends HttpServerLike(rootConfig) {
-    val services = self.services
-    val log = self.logger
-  }
-
-  def server(rootConfig: Configuration, ctx: ExecutionContext) = new HttpServer(rootConfig, ctx)
+trait ServletServer extends ServletEngine with ReflectiveServiceList[ByteChunk] { self =>
+  type HttpServer = HttpServerLike
+  
+  def server(rootConfig: Configuration, ctx: ExecutionContext) = 
+    new HttpServerLike(rootConfig, services, ctx)
 }

--- a/core/src/main/scala/blueeyes/core/http/HttpRequest.scala
+++ b/core/src/main/scala/blueeyes/core/http/HttpRequest.scala
@@ -22,7 +22,7 @@ sealed case class HttpRequest[T] private(method: HttpMethod, uri: URI, parameter
   def map[U](f: T => U): HttpRequest[U] = copy(content = content map f)
 }
 
-object HttpRequest{
+object HttpRequest {
   def apply[T](method: HttpMethod, uri: URI, parameters: Map[Symbol, String] = Map(), headers: HttpHeaders = HttpHeaders.Empty, content: Option[T] = None, remoteHost: Option[InetAddress] = None, version: HttpVersion = `HTTP/1.1`): HttpRequest[T] = {
     val subpath   = uri.path.getOrElse("")
     val query     = uri.query

--- a/core/src/main/scala/blueeyes/core/http/URI.scala
+++ b/core/src/main/scala/blueeyes/core/http/URI.scala
@@ -2,7 +2,7 @@ package blueeyes.core.http
 
 import scala.util.parsing.combinator._
 
-case class URI(scheme: Option[String], userInfo: Option[String], host: Option[String], port: Option[Int], path: Option[String], query: Option[String], fragment: Option[String]){ self =>
+case class URI(scheme: Option[String] = None, userInfo: Option[String] = None, host: Option[String] = None, port: Option[Int] = None, path: Option[String] = None, query: Option[String] = None, fragment: Option[String] = None){ self =>
   import URITranscoders._
   private lazy  val _toString: String = List(scheme.map(_ + ":"), host.orElse(port).map(v =>"//" + authority.getOrElse("")).orElse(authority), path, query.map("?" + _), fragment.map("#" + _)).map(_.getOrElse("")).mkString("")
 
@@ -29,11 +29,11 @@ trait URIGrammar extends RegexParsers {
   def portParser     = (":" ~> (regex("""[\d]+""".r) ^^ {case v => v.toInt}) )?
 
   def authorityParser1 = ("//" ~> userInfoParser ~ hostParser ~ portParser) ^^ {
-    case userInfo ~ host ~ port => URI(None, userInfo, host, port, None, None, None)
+    case userInfo0 ~ host0 ~ port0 => URI(userInfo = userInfo0, host = host0, port = port0)
   }
 
   def authorityParser2 = userInfoParser ^^ {
-    case userInfo => URI(None, userInfo, None, None, None, None, None)
+    case userInfo0 => URI(userInfo = userInfo0)
   }
 
   def authorityParser =  (authorityParser1 | authorityParser2)?

--- a/core/src/main/scala/blueeyes/core/service.scala
+++ b/core/src/main/scala/blueeyes/core/service.scala
@@ -11,20 +11,10 @@ import scalaz.syntax.traverse._
 import scalaz.std.option._
 
 package object service {
-  type AsyncHttpService[T]       = HttpService[T, Future[HttpResponse[T]]]
+  type AsyncHttpService[A, B]    = HttpService[A, Future[HttpResponse[B]]]
   type AsyncHttpTranscoder[A, B] = AsyncTranscoder[HttpRequest, HttpResponse, A, B]
 
-  type HttpClientHandler[T]      = PartialFunction[HttpRequest[T], Future[HttpResponse[T]]]
-
-  type HttpServiceHandler[T, S]  = HttpRequest[T] => S
-
-  type HttpClientTransformer[T, S] = HttpClient[T] => Future[S]
-
   type ServiceDescriptorFactory[T, S] = ServiceContext => ServiceLifecycle[T, S]
-
-  type HttpResponseTransformer[T, S] = HttpResponse[T] => Future[S]
-
-  type HttpServiceCombinator[A, B, C, D] = HttpService[A, B] => HttpService[C, D]
 
   implicit def asyncHttpTranscoder[A, B](implicit M: Monad[Future], projection: A => B, surjection: B => Future[A]): AsyncHttpTranscoder[A, B] = {
     new AsyncTranscoder[HttpRequest, HttpResponse, A, B] {

--- a/core/src/main/scala/blueeyes/core/service/ConfigurableHttpClient.scala
+++ b/core/src/main/scala/blueeyes/core/service/ConfigurableHttpClient.scala
@@ -24,7 +24,7 @@ trait ConfigurableHttpClient {
 
   protected def realClient: HttpClientByteChunk = new HttpClientXLightWeb()
 
-  private def mockClient(h: AsyncHttpService[ByteChunk]): HttpClientByteChunk = new HttpClientByteChunk {
+  private def mockClient(h: AsyncHttpService[ByteChunk, ByteChunk]): HttpClientByteChunk = new HttpClientByteChunk {
     val executor = executionContext
     def isDefinedAt(r: HttpRequest[ByteChunk]) = true
     def apply(r: HttpRequest[ByteChunk]): Future[HttpResponse[ByteChunk]] = h.service(r) match {
@@ -41,7 +41,7 @@ trait ConfigurableHttpClient {
     case e => HttpResponse[ByteChunk](HttpStatus(InternalServerError, Option(e.getMessage).getOrElse("")))
   }
 
-  protected def mockServer: AsyncHttpService[ByteChunk] = new CustomHttpService[ByteChunk, Future[HttpResponse[ByteChunk]]] {
+  protected def mockServer: AsyncHttpService[ByteChunk, ByteChunk] = new CustomHttpService[ByteChunk, Future[HttpResponse[ByteChunk]]] {
     def service = (request: HttpRequest[ByteChunk]) => {
       success(Future(HttpResponse[ByteChunk](HttpStatus(NotFound, "Mock server handles no requests."))))
     }

--- a/core/src/main/scala/blueeyes/core/service/HttpClient.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpClient.scala
@@ -11,7 +11,7 @@ import scalaz.std.option._
 import scalaz.std.string._
 import scalaz.syntax.semigroup._
 
-trait HttpClient[A] extends HttpClientHandler[A] { self =>
+trait HttpClient[A] extends PartialFunction[HttpRequest[A], Future[HttpResponse[A]]] { self =>
   def get[B](path: String)(implicit transcoder: AsyncHttpTranscoder[B, A]) = method[B](HttpMethods.GET, path)
 
   def post[B](path: String)(content: B)(implicit f: B => A, transcoder: AsyncHttpTranscoder[B, A]) = method[B](HttpMethods.POST, path, Some(f(content)))
@@ -149,7 +149,7 @@ trait HttpClient[A] extends HttpClientHandler[A] { self =>
 }
 
 object HttpClient extends blueeyes.bkka.AkkaDefaults {
-  implicit def requestHandlerToHttpClient[A](h: HttpClientHandler[A]): HttpClient[A] = new HttpClient[A] {
+  implicit def requestHandlerToHttpClient[A](h: PartialFunction[HttpRequest[A], Future[HttpResponse[A]]]): HttpClient[A] = new HttpClient[A] {
     def isDefinedAt(r: HttpRequest[A]): Boolean = h.isDefinedAt(r)
 
     def apply(r: HttpRequest[A]): Future[HttpResponse[A]] = h.apply(r)

--- a/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
@@ -204,43 +204,23 @@ trait HttpRequestHandlerCombinators {
    * that have the specified content type. Requires an implicit function
    * used for transcoding.
    */
-  def accept[A, B, A0](mimeTypes: MimeType*)(h: HttpService[Future[A], Future[HttpResponse[B]]])(implicit f: A0 => Future[A]): HttpService[A0, Future[HttpResponse[B]]] = 
+  def accept[A, B](mimeTypes: MimeType*)(h: HttpService[A, B]): HttpService[A, B] = 
     new AcceptService[A, B, A0](mimeTypes, h)
 
-  /** The accept combinator creates a handler that is defined only for requests
-   * that have the specified content type. Requires an implicit function
-   * used for transcoding.
-   */
-  def accept2[A, B, A0, E1](mimeTypes: MimeType*)(h: HttpService[Future[A], E1 => Future[HttpResponse[B]]])(implicit f: A0 => Future[A]) = 
-    new Accept2Service[A, B, A0, E1](mimeTypes, h)
-
   /** The produce combinator creates a handler that is produces responses
    * that have the specified content type. Requires an implicit function
    * used for transcoding.
    */
-  def produce[A, B, B0](mimeType: MimeType)(h: HttpService[A, Future[HttpResponse[B]]])(implicit f: B => B0): HttpService[A, Future[HttpResponse[B0]]] = 
-    new ProduceService(mimeType, h, f)
-
-  /** The produce combinator creates a handler that is produces responses
-   * that have the specified content type. Requires an implicit function
-   * used for transcoding.
-   */
-  def produce2[A, B, B0, E1](mimeType: MimeType)(h: HttpService[A, E1 => Future[HttpResponse[B]]])(implicit f: B => B0): HttpService[A, E1 => Future[HttpResponse[B0]]] = 
-    new Produce2Service(mimeType, h, f)
+  def produce[A, B](mimeType: MimeType)(h: HttpService[A, Future[HttpResponse[B]]]): HttpService[A, Future[HttpResponse[B]]] = 
+    new ProduceService(mimeType, h)
 
   /** The content type combinator creates a handler that accepts and produces
    * requests and responses of the specified content type. Requires an implicit
    * bijection used for transcoding.
    */
-  def contentType[A, B](mimeType: MimeType)(h: HttpService[Future[A], Future[HttpResponse[A]]])(implicit inj: B => Future[A], surj: A => B): HttpService[B, Future[HttpResponse[B]]] = {
+  def contentType[A, B](mimeType: MimeType)(h: HttpService[A, Future[HttpResponse[A]]]): HttpService[A, Future[HttpResponse[B]]] = {
     accept(mimeType) {
       produce[Future[A], A, B](mimeType) { h }
-    }
-  }
-
-  def contentType2[A, B, E1](mimeType: MimeType)(h: HttpService[Future[A], E1 => Future[HttpResponse[A]]])(implicit inj: B => Future[A], surj: A => B): HttpService[B, E1 => Future[HttpResponse[B]]] = {
-    accept2(mimeType) {
-      produce2[Future[A], A, B, E1](mimeType) { h }
     }
   }
 
@@ -249,9 +229,6 @@ trait HttpRequestHandlerCombinators {
    */
   def aggregate(chunkSize: Option[DataSize])(h: HttpService[ByteChunk, Future[HttpResponse[ByteChunk]]])(implicit executor: ExecutionContext) = 
     new AggregateService(chunkSize, h)
-
-  def aggregate2[E1](chunkSize: Option[DataSize])(h: HttpService[ByteChunk, E1 => Future[HttpResponse[ByteChunk]]])(implicit executor: ExecutionContext) = 
-    new Aggregate2Service[E1](chunkSize, h)
 
   /** The jsonp combinator creates a handler that accepts and produces JSON.
    * The handler also transparently works with JSONP, if the client specifies
@@ -262,37 +239,24 @@ trait HttpRequestHandlerCombinators {
   def jsonp[A](delegate: HttpService[A, Future[HttpResponse[A]]])(implicit fromString: String => A, semigroup: Semigroup[A]) = 
     new JsonpService[A](delegate)
 
-  def jsonp2[A, E1](delegate: HttpService[A, E1 => Future[HttpResponse[A]]])(implicit fromString: String => A, semigroup: Semigroup[A]) = 
-    new Jsonp2Service[A, E1](delegate)
-
   /** The jvalue combinator creates a handler that accepts and produces JSON.
    * Requires an implicit bijection used for transcoding.
    */
-  def jvalue[A](h: HttpService[Future[JValue], Future[HttpResponse[JValue]]])(implicit inj: A => Future[JValue], f2: JValue => A): HttpService[A, Future[HttpResponse[A]]] = 
-    contentType(MimeTypes.application/MimeTypes.json) { h }
-
-  def jvalue2[A, E1](h: HttpService[Future[JValue], E1 => Future[HttpResponse[JValue]]])(implicit inj: A => Future[JValue], f2: JValue => A) = 
-    contentType2(MimeTypes.application/MimeTypes.json) { h }
+  def jvalue[A](h: HttpService[Future[JValue], Future[HttpResponse[JValue]]])(implicit inj: A => Future[JValue], surj: JValue => A): HttpService[A, Future[HttpResponse[A]]] = 
+    contentType(MimeTypes.application/MimeTypes.json) { h.contramap(inj) } map { _ map surj }
 
   /** The xml combinator creates a handler that accepts and produces XML.
    * Requires an implicit bijection used for transcoding.
    */
   def xml[A](h: HttpService[Future[NodeSeq], Future[HttpResponse[NodeSeq]]])(implicit inj: A => Future[NodeSeq], surj: NodeSeq => A) = 
-    contentType(MimeTypes.text/MimeTypes.xml) { h }
-
-  def xml2[A, E1](h: HttpService[Future[NodeSeq], E1 => Future[HttpResponse[NodeSeq]]])(implicit inj: A => Future[NodeSeq], surj: NodeSeq => A) = 
-    contentType2(MimeTypes.text/MimeTypes.xml) { h }
+    contentType(MimeTypes.text/MimeTypes.xml) { h.contramap(inj) } map { _ map surj }
 
   def forwarding[A, A0](f: HttpRequest[A] => Option[HttpRequest[A0]], httpClient: HttpClient[A0]) = 
     (h: HttpService[A, HttpResponse[A]]) => new ForwardingService[A, A0](f, httpClient, h)
 
   def metadata[A, B](metadata: Metadata*)(h: HttpService[A, Future[HttpResponse[B]]]) = new MetadataService(Some(AndMetadata(metadata: _*)), h)
 
-  def metadata2[A, B, E1](metadata: Metadata*)(h: HttpService[A, E1 => Future[HttpResponse[B]]]) = new MetadataService(Some(AndMetadata(metadata: _*)), h)
-
   def describe[A, B](description: String)(h: HttpService[A, Future[HttpResponse[B]]]) = new MetadataService(Some(DescriptionMetadata(description)), h)
-
-  def describe2[A, B, E1](description: String)(h: HttpService[A, E1 => Future[HttpResponse[B]]]) = new MetadataService(Some(DescriptionMetadata(description)), h)
 
   /** The decodeUrl combinator creates a handler that decode HttpRequest URI.
    */

--- a/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerCombinators.scala
@@ -240,8 +240,8 @@ trait HttpRequestHandlerCombinators {
    * HTTP method and content using the query string parameters "method" and
    * "content", respectively.
    */
-  def jsonp[A](delegate: AsyncHttpService[A, A])(implicit fromString: String => A, semigroup: Semigroup[A]) = 
-    new JsonpService[A](delegate)
+  def jsonp[A, B](delegate: AsyncHttpService[A, B])(implicit extractReq: String => A, extractResp: String => B, semigroup: Semigroup[B]) = 
+    new JsonpService[A, B](delegate)
 
   /** The jvalue combinator creates a handler that accepts and produces JSON.
    * Requires an implicit bijection used for transcoding.

--- a/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerImplicits.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpRequestHandlerImplicits.scala
@@ -1,11 +1,21 @@
 package blueeyes.core.service
 
+import blueeyes.core.http._
 import blueeyes.util.PartialFunctionCombinators
+
+import scalaz._
+import scalaz.syntax.functor._
 
 trait HttpRequestHandlerImplicits extends PartialFunctionCombinators {
   implicit def identifierToIdentifierWithDefault[S](default: => S) = new ToIdentifierWithDefault(default)
+
   class ToIdentifierWithDefault[S](default: => S){
     def ?: [T](identifier: T) = IdentifierWithDefault[T, S](identifier, Some(default))
   }
+
+  implicit def liftToResponse[A, B, F[_]](resp: F[HttpResponse[A]])(implicit f: A => B, F: Functor[F]): F[HttpResponse[B]] = {
+    resp map { _ map f }
+  }
 }
+
 object HttpRequestHandlerImplicits extends HttpRequestHandlerImplicits

--- a/core/src/main/scala/blueeyes/core/service/HttpServerModule.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServerModule.scala
@@ -103,7 +103,7 @@ trait HttpServerModule extends Logging {
       ServiceContext(rootConfig, serviceConfig, service.name, service.version, service.desc, host, port, sslPort)
     }
 
-    def start: Option[Future[(AsyncHttpService[ByteChunk], Option[Stoppable])]] = {
+    def start: Option[Future[(AsyncHttpService[ByteChunk, ByteChunk], Option[Stoppable])]] = {
       def append[S](lifecycle: ServiceLifecycle[ByteChunk, S], tail: List[Service[ByteChunk, _]]): ServiceLifecycle[ByteChunk, _] = {
         tail match {
           case x :: xs => append(lifecycle ~ x.lifecycle(context(x)), xs)
@@ -119,7 +119,7 @@ trait HttpServerModule extends Logging {
       lifecycle map { _.run map { (trapErrors _).first } }
     }
 
-    def trapErrors(delegate: AsyncHttpService[ByteChunk]): AsyncHttpService[ByteChunk] = new CustomHttpService[ByteChunk, Future[HttpResponse[ByteChunk]]] {
+    def trapErrors(delegate: AsyncHttpService[ByteChunk, ByteChunk]): AsyncHttpService[ByteChunk, ByteChunk] = new CustomHttpService[ByteChunk, Future[HttpResponse[ByteChunk]]] {
       private def convertErrorToResponse(th: Throwable): HttpResponse[ByteChunk] = th match {
         case e: HttpException => HttpResponse[ByteChunk](HttpStatus(e.failure, e.reason))
         case e => {

--- a/core/src/main/scala/blueeyes/core/service/HttpServices.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServices.scala
@@ -19,7 +19,7 @@ import Metadata._
 
 import java.net.URLDecoder._
 
-import scalaz.{ Unapply => _, _ }
+import scalaz._
 import scalaz.syntax.functor._
 import scalaz.syntax.kleisli._
 import scalaz.syntax.show._
@@ -49,9 +49,6 @@ sealed trait HttpService[A, B] extends AnyService { self =>
   }
 
   def ~ (other: HttpService[A, B]): OrService[A, B] = OrService(self, other)
-  def ~ [C, D](other: HttpService[C, D])(implicit unapply: Unapply[C, A], apply: D => B): OrService[A, B] = {
-    self ~ other.contramap(unapply.unapply).map(apply)
-  }
 
   def withMetadata(m: Metadata) = new MetadataService(m, this)
 }

--- a/core/src/main/scala/blueeyes/core/service/HttpServices.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServices.scala
@@ -64,6 +64,10 @@ trait DelegatingService[A, B, A0, B0] extends HttpService[A, B] {
   val delegate: HttpService[A0, B0]
 }
 
+object DelegatingService {
+  def unapply[A, B, C, D](s: DelegatingService[A, B, C, D]): Option[HttpService[C, D]] = Some(s.delegate)
+}
+
 case class OrService[A, B](services: HttpService[A, B]*) extends HttpService[A, B] {
   private def pick(r: HttpRequest[A], services: Seq[HttpService[A, B]]): Validation[NotServed, B] = {
     services.headOption.toSuccess(inapplicable) flatMap {
@@ -84,9 +88,19 @@ case class OrService[A, B](services: HttpService[A, B]*) extends HttpService[A, 
   val metadata = NoMetadata
 }
 
-object DelegatingService {
-  def unapply[A, B, C, D](s: DelegatingService[A, B, C, D]): Option[HttpService[C, D]] = Some(s.delegate)
+trait ResponseModifier[A, B] {
+  def modify(result: A)(f: HttpResponse[B] => HttpResponse[B]): A
 }
+
+object ResponseModifier {
+  implicit def Identity[A, B]: ResponseModifier[A, B] = new ResponseModifier[A, B] {
+    def modify(result: A)(f: HttpResponse[B] => HttpResponse[B]): A = result
+  }
+}
+
+////////////////////////////////////////////////////
+// Handlers that are descendents of the ADT types //
+////////////////////////////////////////////////////
 
 class HttpHandlerService[A, B, C](h: HttpServiceHandler[B, C], f: A => B) extends CustomHttpService[A, C] {
   val service = (r: HttpRequest[A]) => h(r.map(f)).success
@@ -195,49 +209,19 @@ class CommitService[A, B](val delegate: HttpService[A, B]) extends DelegatingSer
   val metadata = NoMetadata
 }
 
-class TranscodeService[A, B](val delegate: HttpService[Future[B], Future[HttpResponse[B]]])(implicit inj: A => Future[B], surj: B => A)
-extends DelegatingService[A, Future[HttpResponse[A]], Future[B], Future[HttpResponse[B]]] {
+class TranscodeService[A, B](val delegate: HttpService[Future[B], Future[HttpResponse[B]]])(implicit inj: A => B, surj: B => A)
+extends DelegatingService[A, Future[HttpResponse[A]], B, Future[HttpResponse[B]]] {
   val service = (request: HttpRequest[A]) => delegate.service(request.map(inj)).map(_.map(_.map(surj)))
   val metadata = NoMetadata
 }
 
-class AcceptService[T, S, U](mimeTypes: Seq[MimeType], val delegate: HttpService[Future[T], Future[HttpResponse[S]]])(implicit f: U => Future[T])
-extends DelegatingService[U, Future[HttpResponse[S]], Future[T], Future[HttpResponse[S]]] {
+class AcceptService[A, B](mimeTypes: Seq[MimeType], val delegate: HttpService[A, B]) extends DelegatingService[A, B, A, B]
   import AcceptService._
-  val service = (r: HttpRequest[U]) => convert(mimeTypes.toSet, r, inapplicable) flatMap { newRequest: HttpRequest[Future[T]] =>
-    delegate.service(newRequest) map { checkConvert(newRequest, _) }
-  }
-
+  val service = (r: HttpRequest[A]) => r.mimeTypes.exists(mimeTypes.toSet).option(r).toSuccess(inapplicable) flatMap { delegate.service }
   val metadata = RequestHeaderMetadata(Right(`Content-Type`(mimeTypes: _*)))
 }
 
-class Accept2Service[T, S, U, E1](mimeTypes: Seq[MimeType], val delegate: HttpService[Future[T], E1 => Future[HttpResponse[S]]])(implicit f: U => Future[T])
-extends DelegatingService[U, E1 => Future[HttpResponse[S]], Future[T], E1 => Future[HttpResponse[S]]] {
-  import AcceptService._
-  val service = (r: HttpRequest[U]) => convert(mimeTypes.toSet, r, inapplicable) flatMap { newRequest: HttpRequest[Future[T]] =>
-    delegate.service(newRequest).map(function => (e: E1) => function.apply(e))
-  }
-
-  val metadata = RequestHeaderMetadata(Right(`Content-Type`(mimeTypes: _*)))
-}
-
-object AcceptService extends blueeyes.bkka.AkkaDefaults {
-  def convert[U, T](mimeTypes: Set[MimeType], r: HttpRequest[U], inapplicable: => Inapplicable)(implicit f: U => Future[T]) = {
-    r.mimeTypes.find(mimeTypes).map(_ => r.copy(content = r.content.map(f)).success).getOrElse(inapplicable.failure)
-  }
-
-  def checkConvert[T, S](request: HttpRequest[Future[T]], response: Future[HttpResponse[S]]) = {
-    request.content.map{content =>
-      val result = Promise[HttpResponse[S]]()
-      content  onFailure { case error => result.success(HttpResponse[S](status = HttpStatus(BadRequest, error.getMessage))) }
-      response onFailure { case error => result.failure(error) }
-      response onSuccess { case value => result.success(value) }
-      result
-    }.getOrElse(response)
-  }
-}
-
-class ProduceService[T, S, V](mimeType: MimeType, val delegate: HttpService[T, Future[HttpResponse[S]]], transcoder: S => V)
+class ProduceService[A, B](mimeType: MimeType, val delegate: HttpService[A, B])
 extends DelegatingService[T, Future[HttpResponse[V]], T, Future[HttpResponse[S]]] {
   import HttpHeaders.Accept
   def service = (r: HttpRequest[T]) => {
@@ -245,21 +229,6 @@ extends DelegatingService[T, Future[HttpResponse[V]], T, Future[HttpResponse[S]]
     filter(_.mimeTypes.exists(mimeType.satisfiesRequestFor)).toSuccess(inapplicable) flatMap { _ =>
       delegate.service(r).map {
         _.map(r => r.copy(content = r.content.map(transcoder), headers = r.headers + `Content-Type`(mimeType)))
-      }
-    }
-  }
-
-  val metadata = ResponseHeaderMetadata(Right(`Content-Type`(mimeType)))
-}
-
-class Produce2Service[T, S, V, E1](mimeType: MimeType, val delegate: HttpService[T, E1 => Future[HttpResponse[S]]], transcoder: S => V)
-extends DelegatingService[T, E1 => Future[HttpResponse[V]], T, E1 => Future[HttpResponse[S]]] {
-  import HttpHeaders.Accept
-  def service = (r: HttpRequest[T]) => {
-    r.headers.header[Accept].orElse(Some(Accept(mimeType))).
-    filter(_.mimeTypes.exists(mimeType.satisfiesRequestFor)).toSuccess(inapplicable) flatMap { _ =>
-      delegate.service(r).map {
-        f => f andThen ((_: Future[HttpResponse[S]]).map(r => r.copy(content = r.content.map(transcoder), headers = r.headers + `Content-Type`(mimeType))))
       }
     }
   }
@@ -326,31 +295,10 @@ extends DelegatingService[ByteChunk, Future[HttpResponse[ByteChunk]], ByteChunk,
   val metadata = opt2M(chunkSize.map(DataSizeMetadata))
 }
 
-class Aggregate2Service[E1](chunkSize: Option[DataSize], val delegate: HttpService[ByteChunk, E1 => Future[HttpResponse[ByteChunk]]])(implicit executor: ExecutionContext)
-extends DelegatingService[ByteChunk, E1 => Future[HttpResponse[ByteChunk]], ByteChunk, E1 => Future[HttpResponse[ByteChunk]]]{
-  private val size = chunkSize.map(_.intBytes).getOrElse(ByteChunk.defaultChunkSize)
-
-  def service = (r: HttpRequest[ByteChunk]) => {
-    delegate.service(r.copy(content = r.content.map(ByteChunk.aggregate(_, size)))).map(f => (e: E1) => f(e))
-  }
-
-  val metadata = opt2M(chunkSize.map(DataSizeMetadata))
-}
-
 class JsonpService[T](val delegate: HttpService[T, Future[HttpResponse[T]]])(implicit fromString: String => T, semigroup: Semigroup[T])
 extends DelegatingService[T, Future[HttpResponse[T]], T, Future[HttpResponse[T]]]{
   import JsonpService._
   def service = (r: HttpRequest[T]) => jsonpConvertRequest(r).flatMap(delegate.service).map(_.map(jsonpConvertResponse(_, r.parameters.get('callback))))
-
-  val metadata = JsonpService.metadata
-}
-
-class Jsonp2Service[T, E1](val delegate: HttpService[T, E1 => Future[HttpResponse[T]]])(implicit fromString: String => T, semigroup: Semigroup[T])
-extends DelegatingService[T, E1 => Future[HttpResponse[T]], T, E1 => Future[HttpResponse[T]]]{
-  import JsonpService._
-  def service = (r: HttpRequest[T]) => {
-    jsonpConvertRequest(r).flatMap(delegate.service).map(f => (e: E1) => f(e).map(jsonpConvertResponse(_, r.parameters.get('callback))))
-  }
 
   val metadata = JsonpService.metadata
 }

--- a/core/src/main/scala/blueeyes/core/service/HttpServices.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServices.scala
@@ -121,6 +121,10 @@ object ResponseModifier {
   implicit def responseF[F[_]: Functor, A]: ResponseModifier[F[HttpResponse[A]]] = new ResponseModifier[F[HttpResponse[A]]] {
     def modify(result: F[HttpResponse[A]])(f: HttpResponse ~> HttpResponse) = result map { r => f[A](r) }
   }
+
+  implicit def responseFG[F[_]: Functor, G[_]: Functor, A]: ResponseModifier[F[G[HttpResponse[A]]]] = new ResponseModifier[F[G[HttpResponse[A]]]] {
+    def modify(result: F[G[HttpResponse[A]]])(f: HttpResponse ~> HttpResponse) = result map { _ map { r => f[A](r) } }
+  }
 }
 
 ////////////////////////////////////////////////////

--- a/core/src/main/scala/blueeyes/core/service/HttpServices.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServices.scala
@@ -316,10 +316,10 @@ extends DelegatingService[ByteChunk, Future[HttpResponse[ByteChunk]], ByteChunk,
   val metadata = opt2M(chunkSize.map(DataSizeMetadata))
 }
 
-class JsonpService[T](val delegate: HttpService[T, Future[HttpResponse[T]]])(implicit fromString: String => T, semigroup: Semigroup[T])
-extends DelegatingService[T, Future[HttpResponse[T]], T, Future[HttpResponse[T]]]{
+class JsonpService[A, B](val delegate: HttpService[A, Future[HttpResponse[B]]])(implicit extractReq: String => A, extractResp: String => B, semigroup: Semigroup[B])
+extends DelegatingService[A, Future[HttpResponse[B]], A, Future[HttpResponse[B]]]{
   import JsonpService._
-  def service = (r: HttpRequest[T]) => jsonpConvertRequest(r).flatMap(delegate.service).map(_.map(jsonpConvertResponse(_, r.parameters.get('callback))))
+  def service = (r: HttpRequest[A]) => jsonpConvertRequest(r).flatMap(delegate.service).map(_.map(jsonpConvertResponse(_, r.parameters.get('callback))))
 
   val metadata = JsonpService.metadata
 }

--- a/core/src/main/scala/blueeyes/core/service/Service.scala
+++ b/core/src/main/scala/blueeyes/core/service/Service.scala
@@ -22,7 +22,7 @@ trait Service[T, S] {
   override def toString = name + "." + version.majorVersion
 }
 
-case class ServiceLifecycle[T, S](startup: () => Future[S], runningState: S => (AsyncHttpService[T], Option[Stoppable])) { self =>
+case class ServiceLifecycle[T, S](startup: () => Future[S], runningState: S => (AsyncHttpService[T, T], Option[Stoppable])) { self =>
   def ~ [S0](that: ServiceLifecycle[T, S0]): ServiceLifecycle[T, (S, S0)] = {
     ServiceLifecycle[T, (S, S0)](
       startup  = () => self.startup() zip that.startup(),
@@ -36,7 +36,7 @@ case class ServiceLifecycle[T, S](startup: () => Future[S], runningState: S => (
     )
   }
 
-  def ~> (that: AsyncHttpService[T]): ServiceLifecycle[T, S] = {
+  def ~> (that: AsyncHttpService[T, T]): ServiceLifecycle[T, S] = {
     self.copy(
       runningState = (s: S) => {
         val (service, stoppable) = self.runningState(s)
@@ -45,7 +45,7 @@ case class ServiceLifecycle[T, S](startup: () => Future[S], runningState: S => (
     )
   }
   
-  def ~ (that: AsyncHttpService[T]): ServiceLifecycle[T, S] = {
+  def ~ (that: AsyncHttpService[T, T]): ServiceLifecycle[T, S] = {
     self.copy(
       runningState = (s: S) => {
         val (service, stoppable) = self.runningState(s)

--- a/core/src/main/scala/blueeyes/core/service/ServiceBuilder.scala
+++ b/core/src/main/scala/blueeyes/core/service/ServiceBuilder.scala
@@ -32,9 +32,9 @@ trait ServiceBuilder[T] {
     StartupDescriptor[T, S](thunk)
   }
   
-  protected def request[S](request: S => AsyncHttpService[T]): RequestDescriptor[T, S] = RequestDescriptor[T, S](request)
+  protected def request[S](request: S => AsyncHttpService[T, T]): RequestDescriptor[T, S] = RequestDescriptor[T, S](request)
   
-  protected def request(request: => AsyncHttpService[T]): RequestDescriptor[T, Unit] = RequestDescriptor[T, Unit]((u) => request)
+  protected def request(request: => AsyncHttpService[T, T]): RequestDescriptor[T, Unit] = RequestDescriptor[T, Unit]((u) => request)
   
   def service[S](sname: String, sversion: ServiceVersion, sdesc: Option[String] = None)(slifecycle: ServiceContext => ServiceLifecycle[T, S]): Service[T, S] = {
     new Service[T, S] {
@@ -82,5 +82,5 @@ case class StartupDescriptor[T, S](startup: () => Future[S]) {
   }
 }
 
-case class RequestDescriptor[T, S](serviceBuilder: S => AsyncHttpService[T])
+case class RequestDescriptor[T, S](serviceBuilder: S => AsyncHttpService[T, T])
 case class ShutdownDescriptor[-S](shutdownBuilder: S => Option[Stoppable])

--- a/core/src/main/scala/blueeyes/core/service/ServiceDescriptorFactoryCombinators.scala
+++ b/core/src/main/scala/blueeyes/core/service/ServiceDescriptorFactoryCombinators.scala
@@ -109,9 +109,11 @@ trait ServiceDescriptorFactoryCombinators extends HttpRequestHandlerCombinators 
             service ~ 
             path(pathPrefix) {
               get {
-                produce(text/html){
-                  (request: HttpRequest[T]) => {
-                    Future(HttpResponse[String](content = Some(ServiceDocumenter.printFormatted(context, service)(Metadata.StringFormatter, HtmlPrinter))))
+                encode {
+                  produce(text/html){
+                    (request: HttpRequest[T]) => {
+                      Future(HttpResponse[String](content = Some(ServiceDocumenter.printFormatted(context, service)(Metadata.StringFormatter, HtmlPrinter))))
+                    }
                   }
                 }
               }

--- a/core/src/main/scala/blueeyes/core/service/ServiceDescriptorFactoryCombinators.scala
+++ b/core/src/main/scala/blueeyes/core/service/ServiceDescriptorFactoryCombinators.scala
@@ -283,7 +283,7 @@ trait ServiceDescriptorFactoryCombinators extends HttpRequestHandlerCombinators 
     }
   }
 
-  private[service] class HttpRequestLoggerService[T](actor: ActorRef, underlying: AsyncHttpService[T])(implicit executor: ExecutionContext) 
+  private[service] class HttpRequestLoggerService[T](actor: ActorRef, underlying: AsyncHttpService[T, T])(implicit executor: ExecutionContext) 
       extends CustomHttpService[T, Future[HttpResponse[T]]]{
     def service = (request: HttpRequest[T]) => {
       try {
@@ -316,7 +316,7 @@ trait ServiceDescriptorFactoryCombinators extends HttpRequestHandlerCombinators 
     val metadata = NoMetadata
   }
 
-  private[service] class MonitorHttpRequestService[T](val delegate: AsyncHttpService[T], healthMonitor: HealthMonitor) extends DelegatingService[T, Future[HttpResponse[T]], T, Future[HttpResponse[T]]] with JPathImplicits{
+  private[service] class MonitorHttpRequestService[T](val delegate: AsyncHttpService[T, T], healthMonitor: HealthMonitor) extends DelegatingService[T, Future[HttpResponse[T]], T, Future[HttpResponse[T]]] with JPathImplicits{
     def service = {request: HttpRequest[T] =>
       val methodName    = request.method.value
       val requestPath   = JPathField(methodName)

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/AbstractNettyEngine.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/AbstractNettyEngine.scala
@@ -6,25 +6,26 @@ import blueeyes.core.data._
 import akka.dispatch.Future
 import akka.dispatch.ExecutionContext
 
+import com.weiglewilczek.slf4s.Logging
+import com.weiglewilczek.slf4s.Logger
 import org.streum.configrity.Configuration
 
 
-trait AbstractNettyEngine extends HttpServerModule {
+trait AbstractNettyEngine extends HttpServerModule { self =>
   type HttpServer <: AbstractNettyHttpServer
 
-  abstract class AbstractNettyHttpServer(rootConfig: Configuration) extends HttpServerLike(rootConfig) {
+  abstract class AbstractNettyHttpServer(rootConfig: Configuration, services: List[Service[ByteChunk, _]], executor0: ExecutionContext) extends HttpServerLike(rootConfig, services, executor0) {
+
     override def start = {
       implicit val stop: Stop[List[NettyServer]] = new Stop[List[NettyServer]] {
-        def stop(servers: List[NettyServer]) = Future {
-          servers.foreach(_.stop)
-        }
+        def stop(servers: List[NettyServer]) = Future(servers.foreach(_.stop))
       }
 
       super.start.map { service =>
         for {
           (service, stoppable) <- service
           servers = nettyServers(service)
-          _ <- Future(servers.foreach(_.start)) 
+          _ <- Future(servers.foreach(_.start))
         } yield {
           (service, Some(Stoppable(servers, stoppable.toList)))
         }

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/AbstractNettyEngine.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/AbstractNettyEngine.scala
@@ -32,6 +32,6 @@ trait AbstractNettyEngine extends HttpServerModule { self =>
       }
     }
 
-    protected def nettyServers(service: AsyncHttpService[ByteChunk]): List[NettyServer]
+    protected def nettyServers(service: AsyncHttpService[ByteChunk, ByteChunk]): List[NettyServer]
   }
 }

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpNettyServerProvider.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpNettyServerProvider.scala
@@ -14,7 +14,7 @@ import com.weiglewilczek.slf4s.Logging
 
 import HttpServerConfig._
 
-private[engines] class HttpNettyServerProvider(conf: HttpServerConfig, service: AsyncHttpService[ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
+private[engines] class HttpNettyServerProvider(conf: HttpServerConfig, service: AsyncHttpService[ByteChunk, ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
   def pipelineFactory(channelGroup: ChannelGroup) = {
     new HttpPipelineFactory("http", conf.host, conf.port, conf.chunkSize, conf.compressionLevel, service, channelGroup, executionContext)
   }
@@ -27,7 +27,7 @@ private[engines] class HttpNettyServerProvider(conf: HttpServerConfig, service: 
 }
 
 private[engines] class HttpPipelineFactory(protocol: String, host: String, port: Int, chunkSize: Int, compression: Option[CompressionLevel],
-                                           service: AsyncHttpService[ByteChunk], channelGroup: ChannelGroup,
+                                           service: AsyncHttpService[ByteChunk, ByteChunk], channelGroup: ChannelGroup,
                                            executionContext: ExecutionContext) extends ChannelPipelineFactory with Logging {
   def getPipeline: ChannelPipeline = {
     val pipeline = Channels.pipeline()

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpNettyServerProvider.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpNettyServerProvider.scala
@@ -14,18 +14,16 @@ import com.weiglewilczek.slf4s.Logging
 
 import HttpServerConfig._
 
-private[engines] class HttpNettyServerProvider(server: HttpServerConfig, service: AsyncHttpService[ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
+private[engines] class HttpNettyServerProvider(conf: HttpServerConfig, service: AsyncHttpService[ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
   def pipelineFactory(channelGroup: ChannelGroup) = {
-    new HttpPipelineFactory("http", server.host, server.port, server.chunkSize, server.compressionLevel, service, channelGroup, executionContext)
+    new HttpPipelineFactory("http", conf.host, conf.port, conf.chunkSize, conf.compressionLevel, service, channelGroup, executionContext)
   }
 
   def engineType = "http"
 
-  def enginePort = server.port
+  def enginePort = conf.port
 
-  def config = server.config
-
-  def log = server.log
+  def config = conf.config
 }
 
 private[engines] class HttpPipelineFactory(protocol: String, host: String, port: Int, chunkSize: Int, compression: Option[CompressionLevel],

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandler.scala
@@ -61,7 +61,7 @@ import scala.collection.mutable.{HashSet, SynchronizedSet}
  *
  * TODO: Pass health monitor to the request handler to report on Netty errors.
  */
-private[engines] class HttpServiceUpstreamHandler(service: AsyncHttpService[ByteChunk], executionContext: ExecutionContext) extends SimpleChannelUpstreamHandler with Logging {
+private[engines] class HttpServiceUpstreamHandler(service: AsyncHttpService[ByteChunk, ByteChunk], executionContext: ExecutionContext) extends SimpleChannelUpstreamHandler with Logging {
   private val pendingResponses = new HashSet[Future[HttpResponse[ByteChunk]]] with SynchronizedSet[Future[HttpResponse[ByteChunk]]]
   private implicit val M: Monad[Future] = new FutureMonad(executionContext)
 

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpsNettyServerProvider.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpsNettyServerProvider.scala
@@ -11,22 +11,21 @@ import org.jboss.netty.channel.group.ChannelGroup
 import org.jboss.netty.channel.ChannelPipeline
 import org.jboss.netty.handler.ssl.SslHandler
 
+import com.weiglewilczek.slf4s.Logger
 import org.streum.configrity.Configuration
 
 import HttpServerConfig._
 
-private[engines] class HttpsNettyServerProvider(server: HttpServerConfig, service: AsyncHttpService[ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
+private[engines] class HttpsNettyServerProvider(conf: HttpServerConfig, service: AsyncHttpService[ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
   def pipelineFactory(channelGroup: ChannelGroup) = {
-    new HttpsPipelineFactory("https", server.host, server.sslPort, server.chunkSize, server.compressionLevel, service, channelGroup, server.config, executionContext)
+    new HttpsPipelineFactory("https", conf.host, conf.sslPort, conf.chunkSize, conf.compressionLevel, service, channelGroup, conf.config, executionContext)
   }
 
   def engineType = "https"
 
-  def enginePort = server.sslPort
+  def enginePort = conf.sslPort
 
-  def config = server.config
-
-  def log = server.log
+  def config = conf.config
 }
 
 private[engines] class HttpsPipelineFactory(protocol: String, host: String, port: Int, chunkSize: Int, compression: Option[CompressionLevel],

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/HttpsNettyServerProvider.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/HttpsNettyServerProvider.scala
@@ -16,7 +16,7 @@ import org.streum.configrity.Configuration
 
 import HttpServerConfig._
 
-private[engines] class HttpsNettyServerProvider(conf: HttpServerConfig, service: AsyncHttpService[ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
+private[engines] class HttpsNettyServerProvider(conf: HttpServerConfig, service: AsyncHttpService[ByteChunk, ByteChunk], executionContext: ExecutionContext) extends AbstractNettyServerProvider {
   def pipelineFactory(channelGroup: ChannelGroup) = {
     new HttpsPipelineFactory("https", conf.host, conf.sslPort, conf.chunkSize, conf.compressionLevel, service, channelGroup, conf.config, executionContext)
   }
@@ -29,7 +29,7 @@ private[engines] class HttpsNettyServerProvider(conf: HttpServerConfig, service:
 }
 
 private[engines] class HttpsPipelineFactory(protocol: String, host: String, port: Int, chunkSize: Int, compression: Option[CompressionLevel],
-                                            requestHandler: AsyncHttpService[ByteChunk], channelGroup: ChannelGroup, 
+                                            requestHandler: AsyncHttpService[ByteChunk, ByteChunk], channelGroup: ChannelGroup, 
                                             config: Configuration, //TODO: Use of Configuration here is bogus
                                             executionContext: ExecutionContext)
     extends HttpPipelineFactory(protocol: String, host, port, chunkSize, compression, requestHandler, channelGroup, executionContext) {

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/NettyEngine.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/NettyEngine.scala
@@ -3,18 +3,19 @@ package engines.netty
 
 import blueeyes.core.data._
 
+import com.weiglewilczek.slf4s.Logger
 import akka.dispatch.ExecutionContext
 import org.streum.configrity.Configuration
 
 trait NettyEngine extends AbstractNettyEngine { self =>
   type HttpServer <: NettyHttpServer
 
-  abstract class NettyHttpServer(rootConfig: Configuration, executionContext: ExecutionContext) extends AbstractNettyHttpServer(rootConfig) { server =>
+  abstract class NettyHttpServer(rootConfig: Configuration, services: List[Service[ByteChunk, _]], executor: ExecutionContext) extends AbstractNettyHttpServer(rootConfig, services, executor) { self =>
     protected def nettyServers(service: AsyncHttpService[ByteChunk]) = {
-      val httpProvider = new HttpNettyServerProvider(server, service, executionContext)
+      val httpProvider = new HttpNettyServerProvider(self.config, service, executor)
       val httpServer = new NettyServer(httpProvider)
-      if (server.sslEnable) {
-        val httpsProvider = new HttpsNettyServerProvider(server, service, executionContext)
+      if (self.config.sslEnable) {
+        val httpsProvider = new HttpsNettyServerProvider(self.config, service, executor)
         val httpsServer = new NettyServer(httpsProvider)
 
         httpServer :: httpsServer :: Nil

--- a/core/src/main/scala/blueeyes/core/service/engines/netty/NettyEngine.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/netty/NettyEngine.scala
@@ -11,7 +11,7 @@ trait NettyEngine extends AbstractNettyEngine { self =>
   type HttpServer <: NettyHttpServer
 
   abstract class NettyHttpServer(rootConfig: Configuration, services: List[Service[ByteChunk, _]], executor: ExecutionContext) extends AbstractNettyHttpServer(rootConfig, services, executor) { self =>
-    protected def nettyServers(service: AsyncHttpService[ByteChunk]) = {
+    protected def nettyServers(service: AsyncHttpService[ByteChunk, ByteChunk]) = {
       val httpProvider = new HttpNettyServerProvider(self.config, service, executor)
       val httpServer = new NettyServer(httpProvider)
       if (self.config.sslEnable) {

--- a/core/src/main/scala/blueeyes/core/service/engines/servlet/ServletEngine.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/servlet/ServletEngine.scala
@@ -23,7 +23,7 @@ import scalaz._
 import scala.collection.mutable.{HashSet, SynchronizedSet}
 
 abstract class ServletEngine extends HttpServlet with HttpServerModule with HttpServletConverters {
-  private var service: AsyncHttpService[ByteChunk] = null
+  private var service: AsyncHttpService[ByteChunk, ByteChunk] = null
   private var stopTimeout: Timeout = null
   private var stoppable: Option[Stoppable] = null
   private var _executionContext: ExecutionContext = null

--- a/core/src/main/scala/blueeyes/core/service/test/BlueEyesServiceSpecification.scala
+++ b/core/src/main/scala/blueeyes/core/service/test/BlueEyesServiceSpecification.scala
@@ -29,7 +29,7 @@ abstract class BlueEyesServiceSpecification extends Specification with FutureMat
   private val NotFound = HttpResponse[ByteChunk](HttpStatus(HttpStatusCodes.NotFound))
   private val mockSwitch = sys.props.get(Environment.MockSwitch)
 
-  private var _service: AsyncHttpService[ByteChunk] = _
+  private var _service: AsyncHttpService[ByteChunk, ByteChunk] = _
   private var _stoppable: Option[Stoppable] = None
 
   implicit def executionContext: ExecutionContext

--- a/core/src/test/scala/blueeyes/core/service/HttpRequestHandlerCombinatorsSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/HttpRequestHandlerCombinatorsSpec.scala
@@ -196,10 +196,8 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
       val handler = path("/foo/bar") {
         cookie('someCookie, Some(defaultValue)) {
           get { 
-            service {
-              (request: HttpRequest[String]) => {
-                cookieVal: String => Future(HttpResponse[String](content = Some(cookieVal)))
-              }
+            (request: HttpRequest[String]) => {
+              cookieVal: String => Future(HttpResponse[String](content = Some(cookieVal)))
             }
           }
         }
@@ -216,9 +214,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
       val handler = path("/foo/'bar") {
         parameter('bar) {
           get { 
-            service {
-              (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[String](content = Some(bar)))
-            }
+            (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[String](content = Some(bar)))
           }
         }
       }
@@ -232,11 +228,9 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
       val handler = path("/foo/") {
         parameter[String, Future[HttpResponse[String]]]('bar, Some("bebe")) {
           get { 
-            service {
-              (request: HttpRequest[String]) => (bar: String) => {
-                request.parameters mustEqual Map('bar -> "bebe")
-                Future(HttpResponse[String](content = request.parameters.get('bar)))
-              }
+            (request: HttpRequest[String]) => (bar: String) => {
+              request.parameters mustEqual Map('bar -> "bebe")
+              Future(HttpResponse[String](content = request.parameters.get('bar)))
             }
           }
         }
@@ -249,12 +243,10 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
 
     "extract parameter even when combined with produce" in {
       val handler = path("/foo/'bar") {
-        produce[String, JValue, JValue](application / json) {
+        produce(application / json) {
           parameter('bar) {
             get { 
-              service {
-                (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[JValue](content = Some(JString(bar))))
-              }
+              (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[JValue](content = Some(JString(bar))))
             }
           }
         }
@@ -267,12 +259,10 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
 
     "extract decoded parameter" in {
       val handler = path("/foo/'bar") {
-        produce[String, JValue, JValue](application / json) {
+        produce(application / json) {
           parameter('bar) {
             get { 
-              service {
-                (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[JValue](content = Some(JString(bar))))
-              }
+              (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[JValue](content = Some(JString(bar))))
             }
           }
         }
@@ -289,10 +279,8 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
       val handler = path('token) {
         parameter('token) {
           get {
-            service {
-              (request: HttpRequest[String]) => { 
-                (token: String) => Future(HttpResponse[String](content = Some(token))) 
-              }
+            (request: HttpRequest[String]) => { 
+              (token: String) => Future(HttpResponse[String](content = Some(token))) 
             }
           }
         }
@@ -306,12 +294,10 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
     "support nested paths" in {
       val handler = path("/foo/") {
         path('bar / "entries") {
-          produce[String, JValue, JValue](application / json) {
+          produce(application / json) {
             parameter('bar) {
               get { 
-                service {
-                  (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[JValue](content = Some(JString(bar))))
-                }
+                (request: HttpRequest[String]) => (bar: String) => Future(HttpResponse[JValue](content = Some(JString(bar))))
               }
             }
           }
@@ -369,7 +355,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
   "decodeUrl combinator" should {
     "decode request URI" in {
       val svc = path("/foo/'bar") {
-        produce[String, JValue, JValue](application / json) {
+        produce(application / json) {
           decodeUrl {
             get { (request: HttpRequest[String]) =>
               Future(HttpResponse[JValue](content = Some(JString(request.uri.toString))))

--- a/core/src/test/scala/blueeyes/core/service/HttpRequestHandlerCombinatorsSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/HttpRequestHandlerCombinatorsSpec.scala
@@ -41,7 +41,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
 
   "composition of paths" should {
     "have the right type" in {
-      val handler: AsyncHttpService[Int] = {
+      val handler: AsyncHttpService[Int, Int] = {
         path("/foo/bar") {
           path("/baz") {
             get { (request: HttpRequest[Int]) =>
@@ -57,7 +57,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
 
   "jsonp combinator" should {
     "detect jsonp by callback & method parameters" in {
-      val handler: AsyncHttpService[ByteChunk] = {
+      val handler: AsyncHttpService[ByteChunk, ByteChunk] = {
         jsonp { transcode {
           path("/") {
             get { (request: HttpRequest[Future[JValue]]) => 
@@ -76,7 +76,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
     }
 
     "retrieve POST content from query string parameter" in {
-      val handler: AsyncHttpService[ByteChunk] = {
+      val handler: AsyncHttpService[ByteChunk, ByteChunk] = {
         jsonp { transcode {
           path("/") {
             post { 
@@ -101,7 +101,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
     }
 
     "retrieve headers from query string parameter" in {
-      val handler: AsyncHttpService[ByteChunk] = {
+      val handler: AsyncHttpService[ByteChunk, ByteChunk] = {
         jsonp { transcode {
           path("/") {
             get { (request: HttpRequest[Future[JValue]]) =>
@@ -123,7 +123,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
     }
 
     "pass undefined to callback when there is no content" in {
-      val handler: AsyncHttpService[ByteChunk] = {
+      val handler: AsyncHttpService[ByteChunk, ByteChunk] = {
         jsonp { transcode {
           path("/") {
             get { (request: HttpRequest[Future[JValue]]) => 
@@ -145,7 +145,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
     }
 
     "return headers in 2nd argument to callback function" in {
-      val handler: AsyncHttpService[ByteChunk] = {
+      val handler: AsyncHttpService[ByteChunk, ByteChunk] = {
         jsonp { transcode[ByteChunk, JValue] {
           path("/") {
             get { (request: HttpRequest[Future[JValue]]) => 
@@ -167,7 +167,7 @@ class HttpRequestHandlerCombinatorsSpec extends Specification
 
 
     "return 200 and propigate status to callback under failure scenarios" in {
-      val errorHandler: AsyncHttpService[ByteChunk] = {
+      val errorHandler: AsyncHttpService[ByteChunk, ByteChunk] = {
         jsonp { transcode {
           path("/") {
             get { (request: HttpRequest[Future[JValue]]) =>

--- a/core/src/test/scala/blueeyes/core/service/HttpServerSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/HttpServerSpec.scala
@@ -65,7 +65,7 @@ object TestServer extends HttpServerModule with TestAkkaDefaults {
     import HttpRequestHandlerImplicits._
     private implicit val M = new blueeyes.bkka.FutureMonad(executor)
 
-    class TestService(svc: AsyncHttpService[ByteChunk]) extends CustomHttpService[ByteChunk, Future[HttpResponse[ByteChunk]]] {
+    class TestService(svc: AsyncHttpService[ByteChunk, ByteChunk]) extends CustomHttpService[ByteChunk, Future[HttpResponse[ByteChunk]]] {
       def metadata = None
       def service = svc.service
       def startupCalled = testServices.startupCalled

--- a/core/src/test/scala/blueeyes/core/service/HttpServiceBuilderSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/HttpServiceBuilderSpec.scala
@@ -21,7 +21,7 @@ class HttpServiceBuilderSpec extends Specification with Mockito with TestAkkaDef
   }
 
   "ServiceBuilder startup: creates StartupDescriptor with specified request function" in{
-    val function = mock[Function[Unit, AsyncHttpService[Unit]]]
+    val function = mock[Function[Unit, AsyncHttpService[Unit, Unit]]]
     val builder  = new ServiceBuilder[Unit]{
       val descriptor = request(function)
     }

--- a/core/src/test/scala/blueeyes/core/service/engines/TestEngineService.scala
+++ b/core/src/test/scala/blueeyes/core/service/engines/TestEngineService.scala
@@ -26,30 +26,33 @@ import scalaz.syntax.monad._
 
 trait TestEngineService extends BlueEyesServiceBuilder with HttpRequestCombinators with TestAkkaDefaults {
   import blueeyes.core.http.MimeTypes._
+  import HttpRequestHandlerImplicits._
 
   private val response = HttpResponse[String](status = HttpStatus(HttpStatusCodes.OK), content = Some(TestEngineService.content))
 
   val sampleService = service("sample", "1.32") { _ =>
     request {
-      produce[ByteChunk, String, ByteChunk](text/html) {
-        path("/bar/'adId/adCode.html") {
-          get { request: HttpRequest[ByteChunk] =>
-            Future[HttpResponse[String]](response)
-          }
-        } ~
-        path("/foo") {
-          get { request: HttpRequest[ByteChunk] =>
-            Future[HttpResponse[String]](response)
-          }
-        } ~
-        path("/error") {
-          get[ByteChunk, Future[HttpResponse[String]]] { request: HttpRequest[ByteChunk] =>
-            throw new RuntimeException("Unexpected error (GET /error)")
-          }
-        } ~
-        path("/http/error") {
-          get[ByteChunk, Future[HttpResponse[String]]] { request: HttpRequest[ByteChunk] =>
-            throw HttpException(HttpStatusCodes.BadRequest)
+      encode[ByteChunk, Future[HttpResponse[String]], Future[HttpResponse[ByteChunk]]] {
+        produce(text/html) {
+          path("/bar/'adId/adCode.html") {
+            get { request: HttpRequest[ByteChunk] =>
+              Future[HttpResponse[String]](response)
+            }
+          } ~
+          path("/foo") {
+            get { request: HttpRequest[ByteChunk] =>
+              Future[HttpResponse[String]](response)
+            }
+          } ~
+          path("/error") {
+            get[ByteChunk, Future[HttpResponse[String]]] { request: HttpRequest[ByteChunk] =>
+              throw new RuntimeException("Unexpected error (GET /error)")
+            }
+          } ~
+          path("/http/error") {
+            get[ByteChunk, Future[HttpResponse[String]]] { request: HttpRequest[ByteChunk] =>
+              throw HttpException(HttpStatusCodes.BadRequest)
+            }
           }
         }
       } ~

--- a/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServerNettySpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServerNettySpec.scala
@@ -59,7 +59,7 @@ class HttpServerNettySpec extends Specification with TestAkkaDefaults with HttpR
     def startStep = Step {
       val conf = Configuration.parse(configPattern.format(port, sslPort), BlockFormat)
       val sampleServer = (new SampleServer).server(conf, defaultFutureDispatch)
-      config = sampleServer.config
+      config = conf.detach("server")
 
       sampleServer.start map { startFuture =>
         Await.result(startFuture map { case (_, shutdown) => stop = shutdown }, duration)

--- a/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandlerSpec.scala
+++ b/core/src/test/scala/blueeyes/core/service/engines/netty/HttpServiceUpstreamHandlerSpec.scala
@@ -32,7 +32,7 @@ import scalaz._
 class HttpServiceUpstreamHandlerSpec extends Specification with Mockito with Logging with TestAkkaDefaults with FutureMatchers {
   import HttpNettyConverters._
 
-  private val handler       = mock[AsyncHttpService[ByteChunk]]
+  private val handler       = mock[AsyncHttpService[ByteChunk, ByteChunk]]
   private val context       = mock[ChannelHandlerContext]
   private val channel       = mock[Channel]
   private val channelFuture = mock[ChannelFuture]

--- a/json/src/main/scala/blueeyes/json/AsyncParser.scala
+++ b/json/src/main/scala/blueeyes/json/AsyncParser.scala
@@ -36,7 +36,7 @@ final class AsyncParser protected[json] (
   protected[this] final def copy() =
     new AsyncParser(data.clone, len, allocated, index, done, failFast)
 
-  final def apply(b: Option[ByteBuffer]): (AsyncParse, AsyncParser) = copy.feed(b)
+  final def apply(b: ByteBuffer): (AsyncParse, AsyncParser) = copy.feed(Some(b))
 
   protected[this] final def absorb(buf: ByteBuffer): Unit = {
     done = false

--- a/json/src/main/scala/blueeyes/json/serialization/Decomposer.scala
+++ b/json/src/main/scala/blueeyes/json/serialization/Decomposer.scala
@@ -20,6 +20,10 @@ trait Decomposer[A] { self =>
   }
 }
 
+object Decomposer {
+  def apply[A](implicit d: Decomposer[A]): Decomposer[A] = d
+}
+
 /** Serialization implicits allow a convenient syntax for serialization and 
  * deserialization when implicit decomposers and extractors are in scope.
  * <p>

--- a/json/src/main/scala/blueeyes/json/serialization/Extractor.scala
+++ b/json/src/main/scala/blueeyes/json/serialization/Extractor.scala
@@ -37,6 +37,8 @@ trait Extractor[A] { self =>
 }
 
 object Extractor {
+  def apply[A](implicit e: Extractor[A]): Extractor[A] = e
+
   def invalidv[A](message: String) = failure[Error, A](Invalid(message))
   def tryv[A](a: => A) = (Thrown.apply _) <-: Validation.fromTryCatch(a)
 

--- a/json/src/main/scala/blueeyes/json/serialization/Extractor.scala
+++ b/json/src/main/scala/blueeyes/json/serialization/Extractor.scala
@@ -31,6 +31,10 @@ trait Extractor[A] { self =>
     def validated(jvalue: JValue) = self.validated(jvalue) map f
   }
 
+  def mapv[B](f: A => Validation[Error, B]): Extractor[B] = new Extractor[B] {
+    def validated(jvalue: JValue) = self.validated(jvalue) flatMap f
+  }
+
   def kleisli = Kleisli[({type λ[+α] = Validation[Error, α]})#λ, JValue, A](validated _)
 
   def apply(jvalue: JValue): A = extract(jvalue)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -60,7 +60,7 @@ object BlueEyesBuild extends Build {
     }
   )
 
-  val scalazVersion = "7.0.0-RC2"
+  val scalazVersion = "7.0.0"
 
   val commonSettings = Seq(
     scalaVersion := "2.9.2",


### PR DESCRIPTION
Some combinators were performing more than one operation, which made them hard to compose - for example, request and response transcoding as well as checking and setting request headers. While this is appropriate for some higher-level combinators, the fundamental building block combinators should not be doing this.
