### PR TITLE
Make jvalue header lenient if request body is empty.

### DIFF
--- a/core/src/main/scala/blueeyes/core/service/HttpServices.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServices.scala
@@ -156,6 +156,15 @@ class DebugService[A, B](logger: Logger, val delegate: HttpService[A, B]) extend
   val metadata = NoMetadata
 }
 
+class IfRequestService[A, B](p: HttpRequest[A] => Boolean, val delegate: HttpService[A, B]) extends DelegatingService[A, B, A, B] {
+  val service = (req: HttpRequest[A]) => {
+    if (p(req)) delegate.service(req) else Failure(inapplicable)
+  }
+
+  val metadata = NoMetadata
+}
+
+
 class HealthMonitorService[A, B](context: ServiceContext, monitor: HealthMonitor, startTime: Long)(implicit jv2b: JValue => B) extends CustomHttpService[A, Future[HttpResponse[B]]] {
   val service = (req: HttpRequest[A]) => Success {
     import scalaz.syntax.show._

--- a/core/src/main/scala/blueeyes/core/service/engines/HttpClientXLightweb.scala
+++ b/core/src/main/scala/blueeyes/core/service/engines/HttpClientXLightweb.scala
@@ -109,6 +109,12 @@ class HttpClientXLightWeb(implicit val executor: ExecutionContext) extends HttpC
       }
     }
 
+    logger.trace("Executing request of type " + xlrequest.getClass())
+    logger.trace("xlRequest content type: " + xlrequest.getContentType())
+    for (name <- xlrequest.getHeaderNames.asScala) {
+      logger.trace("Header %s has values %s".format(name, xlrequest.getHeaderList(name.asInstanceOf[String]).asScala.mkString("[", ", ", "]")))
+    }
+
     xlrequest match {
       case e: IHttpRequest => 
         clientInstance.send(e, handler)


### PR DESCRIPTION
HttpClientXLightWeb sends text/plain for the Content-Type header if the request
body is empty, even if some other content-type is specified. This changes the
jvalue combinator to be lenient with respect to content-type if the request
body is in fact empty.
