### PR TITLE
Avoid recursively calling toString on nested JValues.

### DIFF
--- a/json/src/main/scala/blueeyes/json/JValue.scala
+++ b/json/src/main/scala/blueeyes/json/JValue.scala
@@ -863,6 +863,8 @@ case class JObject(fields: Map[String, JValue]) extends JValue {
   assert(fields != null)
   assert(fields.values.forall(_ != null))
 
+  override def toString(): String = "JObject(<%d fields>)" format fields.size
+
   def get(name: String): JValue = fields.get(name).getOrElse(JUndefined)
 
   def hasDefinedChild: Boolean = fields.values.exists(_ != JUndefined) 
@@ -1012,6 +1014,8 @@ case object JObject extends (Map[String, JValue] => JObject) {
 
 case class JArray(elements: List[JValue]) extends JValue {
   assert(elements.forall(_ != null))
+
+  override def toString(): String = "JArray(<%d values>)" format elements.length
 
   def hasDefinedChild: Boolean = elements exists { _ != JUndefined }
 


### PR DESCRIPTION
This commit fixes problems where logging frameworks, the REPL, etc.
could create massive strings representing gigantic JSON arrays.
After this change, only the top-level class will be printed, e.g.

  JArray(<12452 values>)

To generate an actual JSON string, use renderCompact (to minimize the
size of JSON produced), renderPretty (for whitespace and indentation),
or renderCanonical (like renderPretty but also sorts fields in JObject
to assist string equality testing).
