### PR TITLE
Allow empty content-type header for jvalue requests.

### DIFF
--- a/core/src/main/scala/blueeyes/core/service/HttpServices.scala
+++ b/core/src/main/scala/blueeyes/core/service/HttpServices.scala
@@ -253,8 +253,8 @@ extends DelegatingService[A, Future[HttpResponse[A]], Future[B], Future[HttpResp
   val metadata = NoMetadata
 }
 
-class AcceptService[A, B](mimeTypes: Seq[MimeType], val delegate: HttpService[A, B]) extends DelegatingService[A, B, A, B] {
-  val service = (r: HttpRequest[A]) => r.mimeTypes.exists(mimeTypes.toSet).option(r).toSuccess(inapplicable) flatMap { delegate.service }
+class AcceptService[A, B](mimeTypes: Seq[MimeType], strict: Boolean, val delegate: HttpService[A, B]) extends DelegatingService[A, B, A, B] {
+  val service = (r: HttpRequest[A]) => (r.mimeTypes.exists(mimeTypes.toSet) || (!strict && r.mimeTypes.isEmpty)).option(r).toSuccess(inapplicable) flatMap { delegate.service }
   val metadata = RequestHeaderMetadata(Right(`Content-Type`(mimeTypes: _*)))
 }
 


### PR DESCRIPTION
This is a slightly dodgy change, but otherwise we break backwards
API compatibility for clients of blueeyes services, which is
dodgier.
