### PR TITLE
Extend JPath to accept quoted string references

### DIFF
--- a/json/src/main/scala/blueeyes/json/JPathParser.scala
+++ b/json/src/main/scala/blueeyes/json/JPathParser.scala
@@ -1,0 +1,73 @@
+package blueeyes.json
+
+import scala.util.parsing.combinator._
+import scalaz.\/
+import scalaz.syntax.id._
+
+
+object JPathParser extends RegexParsers {
+
+  def parse(in: String): String \/ List[JPathNode] =
+    this.parseAll(jPath, in) match {
+      case Success(result, _) => result.right
+      case failure: NoSuccess => failure.msg.left
+    }
+
+  def identifier: Parser[String] =
+    "[a-zA-Z_$][a-zA-Z_$0-9]*".r
+
+
+  def jPath: Parser[List[JPathNode]] =
+    ((identifier ^^ { JPathField(_) }) | pathElement) ~ (pathElement.*) ^^ {
+      case n ~ ns => n +: ns
+    }
+
+
+  def pathElement: Parser[JPathNode] =
+    field | index
+
+
+  def field: Parser[JPathField] =
+    "." ~ identifier ^^ { case dot ~ id => JPathField(id) }
+
+
+  def index: Parser[JPathIndex] =
+    sqIndexField | dqIndexField | numericIndexField
+
+
+
+  def numericIndexField: Parser[JPathIndex] = {
+    def index: Parser[Int] =
+      """\d+""".r ^^ { _.toInt }
+
+    "[" ~ index ~ "]" ^^ { case lb ~ id ~ rb => JPathIndex(id) }
+  }
+
+
+  def dqIndexField: Parser[JPathIndex] = {
+    def unquotedString: Parser[String] =
+      """[^"\\]+""".r
+
+    def quotedString: Parser[String] =
+      """\\.""".r ^^ { _.replace("\\", "") }
+
+    def index: Parser[String] =
+      ( unquotedString | quotedString ).* ^^ { _.mkString }
+
+    "[\"" ~ index ~ "\"]" ^^ { case lq ~ id ~ rq => JPathIndex(id) }
+  }
+
+
+  def sqIndexField: Parser[JPathIndex] = {
+    def unquotedString: Parser[String] =
+      """[^'\\]+""".r
+
+    def quotedString: Parser[String] =
+      """\\.""".r ^^ { _.replace("\\", "") }
+
+    def index: Parser[String] =
+      ( unquotedString | quotedString ).* ^^ { _.mkString }
+
+    "['" ~ index ~ "']" ^^ { case lq ~ id ~ rq => JPathIndex(id) }
+  }
+}

--- a/json/src/test/scala/blueeyes/json/JPathSpec.scala
+++ b/json/src/test/scala/blueeyes/json/JPathSpec.scala
@@ -28,8 +28,8 @@ import org.specs2.ScalaCheck
 object JPathSpec extends Specification with ScalaCheck with ArbitraryJPath with ArbitraryJValue {
   "Parser" should {
     "parse all valid JPath strings" in {
-      check { (jpath: JPath) =>
-        JPath(jpath.toString) == jpath
+      check { path: (String, JPath) =>
+        JPath(path._1) == path._2
       }
     }
 
@@ -47,7 +47,7 @@ object JPathSpec extends Specification with ScalaCheck with ArbitraryJPath with 
 
       check { (testData: (JValue, List[(JPath, JValue)])) =>
         testData match {
-          case (obj, allPathValues) => 
+          case (obj, allPathValues) =>
             val allProps = allPathValues.map {
               case (path, pathValue) => path.extract(obj) == pathValue
             }
@@ -60,6 +60,17 @@ object JPathSpec extends Specification with ScalaCheck with ArbitraryJPath with 
       val j = JObject(JField("address", JObject( JField("city", JString("B")) :: JField("street", JString("2")) ::  Nil)) :: Nil)
 
       JPath("address.city").extract(j) mustEqual(JString("B"))
+    }
+
+    "extract quoted field references" in {
+      val json = JObject(List(JField("foo",
+                   JObject(List(JField("bar bar",
+                     JObject(List(JField("ba-sil",
+                       JString("bingo!"))))))))))
+
+      JPath("foo['bar bar']['ba-sil']").extract(json) mustEqual JString("bingo!")
+      JPath("""foo["bar bar"]["ba-sil"]""").extract(json) mustEqual JString("bingo!")
+      JPath("""foo["bar bar"]['ba-sil']""").extract(json) mustEqual JString("bingo!")
     }
   }
 


### PR DESCRIPTION
JPath syntax is now (roughly)

  jPath := pathElement*
  pathElement := id | quotedField | numericField
  id := .[a-zA-Z_$][a-zA-Z_$0-9]*
  quotedField := ['quotedId'] | ["quotedId"]
  numericField := [<integer>]

  quotedId is a string with \ used as an escape character.

  The first element of a jPath need not start with a . if it is an id

Example:

  foo['bar bar']["black sheep"] is a valid reference into

  {"foo": {"bar bar": {"black sheep": "aValue"}}}
