### PR TITLE
Parse empty JPath

### DIFF
--- a/json/src/main/scala/blueeyes/json/JPathParser.scala
+++ b/json/src/main/scala/blueeyes/json/JPathParser.scala
@@ -17,10 +17,18 @@ object JPathParser extends RegexParsers {
     "[a-zA-Z_$][a-zA-Z_$0-9]*".r
 
 
-  def jPath: Parser[List[JPathNode]] =
-    ((identifier ^^ { JPathField(_) }) | pathElement) ~ (pathElement.*) ^^ {
-      case n ~ ns => n +: ns
-    }
+  def jPath: Parser[List[JPathNode]] = {
+    def elements: Parser[List[JPathNode]] =
+      ((identifier ^^ { JPathField(_) }) | pathElement) ~ (pathElement.*) ^^ {
+        case n ~ ns => n +: ns
+      }
+
+    identity | elements
+  }
+
+
+  def identity: Parser[List[JPathNode]] =
+    """^\s*\.?\s*$""".r ^^ { _ => List.empty[JPathNode] }
 
 
   def pathElement: Parser[JPathNode] =

--- a/json/src/test/scala/blueeyes/json/JPathSpec.scala
+++ b/json/src/test/scala/blueeyes/json/JPathSpec.scala
@@ -36,6 +36,13 @@ object JPathSpec extends Specification with ScalaCheck with ArbitraryJPath with 
     "forgivingly parse initial field name without leading dot" in {
       JPath("foo.bar").nodes mustEqual (JPathField("foo") :: JPathField("bar") :: Nil)
     }
+
+    "parse identity" in {
+      JPath("") mustEqual JPath.Identity
+      JPath(".") mustEqual JPath.Identity
+      JPath("  ") mustEqual JPath.Identity
+      JPath("  .  ") mustEqual JPath.Identity
+    }
   }
 
   "Extractor" should {


### PR DESCRIPTION
JPaths like "." or "" are now parsed as the empty JPath.
