### PR TITLE
Fix thread safety issue parsing JPaths

### DIFF
--- a/json/src/main/scala/blueeyes/json/JPath.scala
+++ b/json/src/main/scala/blueeyes/json/JPath.scala
@@ -180,7 +180,7 @@ object JPath extends JPathSerialization {
   def unapplySeq(path: String): Option[List[JPathNode]] = Some(apply(path).nodes)
 
   implicit def apply(path: String): JPath = {
-    JPathParser.parse(path).fold(
+    new JPathParser().parse(path).fold(
       l = msg   => JPath(),
       r = nodes => JPath(nodes)
     )

--- a/json/src/main/scala/blueeyes/json/JPathParser.scala
+++ b/json/src/main/scala/blueeyes/json/JPathParser.scala
@@ -5,7 +5,7 @@ import scalaz.\/
 import scalaz.syntax.id._
 
 
-object JPathParser extends RegexParsers {
+class JPathParser extends RegexParsers {
 
   def parse(in: String): String \/ List[JPathNode] =
     this.parseAll(jPath, in) match {


### PR DESCRIPTION
Scala parser combinators are not thread safe in 2.9.2.

https://issues.scala-lang.org/browse/SI-4929
